### PR TITLE
Revert html link back to intersphinx reference:

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ as a python package. This repository is structured as follows:
 Installation
 ------------
 
-Please refer to `Installation of MALA <https://multiscale-wdm.pages.hzdr.de/surrogate-models/fesl/fesl/install/README.html>`_.
+Please refer to :doc:`Installation of FESL <install/README>`.
 
 Running
 -------


### PR DESCRIPTION
Although :doc: is a special role directive of Sphinx and is not in the
reStructuredText Markup Specification and hence rST viewers do not
render it, its usage is beneficial since html links may change, but the
symbolic label retains.

This is linked to #111 