### PR TITLE
Fix type of `params` in class `HyperOptOptuna`

### DIFF
--- a/mala/network/hyper_opt_optuna.py
+++ b/mala/network/hyper_opt_optuna.py
@@ -15,7 +15,7 @@ class HyperOptOptuna(HyperOptBase):
 
     Parameters
     ----------
-    params : mala.common.parametes.Parameters
+    params : mala.common.parameters.Parameters
         Parameters used to create this hyperparameter optimizer.
 
     data : mala.datahandling.data_handler.DataHandler


### PR DESCRIPTION
Fix typo in type of parameter in docstring of class `HyperOptOptuna`. By fixing this this becomes a hyperlink to the corresponding documentation.