### PR TITLE
Optuna objectives can train multiple networks now

### DIFF
--- a/mala/common/parameters.py
+++ b/mala/common/parameters.py
@@ -515,6 +515,18 @@ class ParametersHyperparameterOptimization(ParametersBase):
         else:
             self._rdb_storage_heartbeat = value
 
+    @property
+    def number_training_per_trial(self):
+        """Control how many trainings are run per optuna trial."""
+        return self._number_training_per_trial
+
+    @number_training_per_trial.setter
+    def number_training_per_trial(self, value):
+        if value < 1:
+            self._number_training_per_trial = 1
+        else:
+            self._number_training_per_trial = value
+
     def show(self, indent=""):
         """
         Print name and values of all attributes of this object.

--- a/mala/network/objective_base.py
+++ b/mala/network/objective_base.py
@@ -5,6 +5,7 @@ from .hyperparameter_optuna import HyperparameterOptuna
 from .hyperparameter_oat import HyperparameterOAT
 from .network import Network
 from .trainer import Trainer
+from mala import printout
 
 
 class ObjectiveBase:
@@ -62,6 +63,10 @@ class ObjectiveBase:
             test_trainer = Trainer(self.params, test_network, self.data_handler)
             test_trainer.train_network()
             final_validation_loss.append(test_trainer.final_validation_loss)
+
+        if self.params.hyperparameters.number_training_per_trial > 1:
+            printout("Losses from multiple runs are: ")
+            printout(final_validation_loss)
         return np.mean(final_validation_loss)
 
     def parse_trial(self, trial):


### PR DESCRIPTION
With this PR, optuna can train multiple networks and take the mean of the final accuracies as metric. This helps discard architectures who just randomly got a good run, which can happen. 