### PR TITLE
Add Citation file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cff   linguist-language=YAML

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+# YAML 1.2
+cff-version: 1.1.0
+message: "If you use this software, please cite it using these metadata."
+authors:
+  - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
+    family-names: Fiedler
+    given-names: Lenz
+  - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
+    family-names: Kotik
+    given-names: Daniel
+  - affiliation: "Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
+    family-names: Schmerler
+    given-names: Steve
+  - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
+    family-names: Cangi
+    given-names: Attila
+#date-released: 2021-08-16
+keywords:
+  - "machine-learning"
+  - "dft"
+license: "BSD-3-Clause"
+repository-code: "https://github.com/mala-project/mala"
+title: mala
+# doi:
+version: 0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,6 +11,7 @@ authors:
   - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
     family-names: Fiedler
     given-names: Lenz
+    orcid: https://orcid.org/0000-0002-8311-0613
   - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
     family-names: Kotik
     given-names: Daniel

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,6 +14,7 @@ authors:
   - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
     family-names: Kotik
     given-names: Daniel
+    orcid: https://orcid.org/0000-0001-8735-3199
   - affiliation: "Sandia National Laboratories (SNL)"
     family-names: Modine
     given-names: Normand A.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,7 +31,7 @@ authors:
     given-names: Steve
   - affiliation: "Sandia National Laboratories (SNL)"
     family-names: Stephens
-    given-names: John A.
+    given-names: J. Adam
   - affiliation: "Sandia National Laboratories (SNL)"
     family-names: Thompson
     given-names: Aidan P.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,17 +3,40 @@ cff-version: 1.1.0
 message: "If you use this software, please cite it using these metadata."
 authors:
   - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
+    family-names: Cangi
+    given-names: Attila
+  - affiliation: "Oak Ridge National Laboratory (ORNL)"
+    family-names: Ellis
+    given-names: J. Austin
+  - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
     family-names: Fiedler
     given-names: Lenz
   - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
     family-names: Kotik
     given-names: Daniel
+  - affiliation: "Sandia National Laboratories (SNL)"
+    family-names: Modine
+    given-names: Normand A.
+  - affiliation: "Oak Ridge National Laboratory (ORNL)"
+    family-names: Oles
+    given-names: Vladyslav
+  - affiliation: "Sandia National Laboratories (SNL)"
+    family-names: Popoola
+    given-names: Gabriel A.
+  - affiliation: "Sandia National Laboratories (SNL)"
+    family-names: Rajamanickam
+    given-names: Siva
   - affiliation: "Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
     family-names: Schmerler
     given-names: Steve
-  - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
-    family-names: Cangi
-    given-names: Attila
+  - affiliation: "Sandia National Laboratories (SNL)"
+    family-names: Stephens
+    given-names: John A.
+  - affiliation: "Sandia National Laboratories (SNL)"
+    family-names: Thompson
+    given-names: Aidan P.
+
+
 #date-released: 2021-08-16
 keywords:
   - "machine-learning"


### PR DESCRIPTION
See https://citation-file-format.github.io/ for details. GitHub supports citation files, see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files. Zenodo added support for `CITATION.cff` as well. Once we got a DOI, we can add it to this file as well.

@RandomDefaultUser Please add all main package contributors as authors to this file with their correct affiliation.