### PR TITLE
Fix building of Docker image from `Dockerfile`:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM continuumio/miniconda3:4.9.2
 ARG DEVICE=cpu
 
 # Update the image to the latest packages
-RUN apt-get update && apt-get upgrade -y
+RUN apt-get --allow-releaseinfo-change update && apt-get upgrade -y
 
 RUN apt-get install --no-install-recommends -y build-essential libz-dev swig git-lfs
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The build fails at `RUN apt-get update` with message `E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'`.

Fix according to https://stackoverflow.com/questions/68802802/repository-http-security-debian-org-debian-security-buster-updates-inrelease

Closes 
- #187