### PR TITLE
Use os.path.join in DataHandler

### DIFF
--- a/mala/datahandling/data_converter.py
+++ b/mala/datahandling/data_converter.py
@@ -1,4 +1,6 @@
 """DataConverter class for converting snapshots into numpy arrays."""
+import os
+
 from mala.common.printout import printout
 from mala.common.parameters import ParametersData
 from mala.descriptors.descriptor_interface import DescriptorInterface
@@ -176,5 +178,7 @@ class DataConverter:
             snapshot_name = naming_scheme
             snapshot_name = snapshot_name.replace("*", str(snapshot_number))
             printout("Saving snapshot", snapshot_number, "at ", save_path)
-            np.save(save_path+snapshot_name+".in.npy", input_data)
-            np.save(save_path+snapshot_name+".out.npy", output_data)
+            np.save(os.path.join(save_path, snapshot_name+".in.npy"),
+                    input_data)
+            np.save(os.path.join(save_path, snapshot_name+".out.npy"),
+                    output_data)

--- a/mala/datahandling/data_handler.py
+++ b/mala/datahandling/data_handler.py
@@ -1,4 +1,7 @@
 """DataHandler class that loads and scales data."""
+
+import os
+
 from torch.utils.data import TensorDataset
 
 from .data_scaler import DataScaler
@@ -344,17 +347,17 @@ class DataHandler:
         i = 0
         snapshot: Snapshot
         for snapshot in self.parameters.snapshot_directories_list:
-            tmp_array = self.__load_from_npy_file(snapshot.input_npy_directory
-                                                  + snapshot.input_npy_file)
+            tmp_array = self.__load_from_npy_file(os.path.join(snapshot.input_npy_directory,
+                                                               snapshot.input_npy_file))
             tmp_file_name = naming_scheme_input
             tmp_file_name = tmp_file_name.replace("*", str(i))
             np.save(directory+tmp_file_name+".npy", tmp_array)
 
-            tmp_array = self.__load_from_npy_file(snapshot.output_npy_directory
-                                                  + snapshot.output_npy_file)
+            tmp_array = self.__load_from_npy_file(os.path.join(snapshot.output_npy_directory,
+                                                               snapshot.output_npy_file))
             tmp_file_name = naming_scheme_output
             tmp_file_name = tmp_file_name.replace("*", str(i))
-            np.save(directory+tmp_file_name+".npy", tmp_array)
+            np.save(os.path.join(directory, tmp_file_name + ".npy"), tmp_array)
             i += 1
 
     def get_snapshot_calculation_output(self, snapshot_number):
@@ -398,8 +401,8 @@ class DataHandler:
 
             printout("Checking descriptor file ", snapshot.input_npy_file,
                      "at", snapshot.input_npy_directory)
-            tmp = self.__load_from_npy_file(snapshot.input_npy_directory +
-                                            snapshot.input_npy_file,
+            tmp = self.__load_from_npy_file(os.path.join(snapshot.input_npy_directory,
+                                                         snapshot.input_npy_file),
                                             mmapmode='r')
 
             # We have to cut xyz information, if we have xyz information in
@@ -430,8 +433,8 @@ class DataHandler:
 
             printout("Checking targets file ", snapshot.output_npy_file, "at",
                      snapshot.output_npy_directory)
-            tmp_out = self.__load_from_npy_file(snapshot.output_npy_directory +
-                                                snapshot.output_npy_file,
+            tmp_out = self.__load_from_npy_file(os.path.join(snapshot.output_npy_directory,
+                                                             snapshot.output_npy_file),
                                                 mmapmode='r')
 
             # The first snapshot determines the data size to be used.
@@ -752,8 +755,8 @@ class DataHandler:
                 if self.parameters.data_splitting_snapshots[i] == "va" \
                         or self.parameters.data_splitting_snapshots[i] == "te":
                     tmp = self.\
-                        __load_from_npy_file(snapshot.input_npy_directory +
-                                             snapshot.input_npy_file,
+                        __load_from_npy_file(os.path.join(snapshot.input_npy_directory,
+                                                          snapshot.input_npy_file),
                                              mmapmode='r')
                     if self.parameters.descriptors_contain_xyz:
                         tmp = tmp[:, :, :, 3:]
@@ -765,8 +768,8 @@ class DataHandler:
                     if self.parameters.data_splitting_snapshots[i] == "te":
                         self.test_data_inputs.append(tmp)
                     tmp = self.\
-                        __load_from_npy_file(snapshot.output_npy_directory +
-                                             snapshot.output_npy_file,
+                        __load_from_npy_file(os.path.join(snapshot.output_npy_directory,
+                                                          snapshot.output_npy_file),
                                              mmapmode='r')
                     tmp = np.array(tmp)
                     tmp *= self.target_calculator.\

--- a/mala/datahandling/data_handler.py
+++ b/mala/datahandling/data_handler.py
@@ -351,7 +351,7 @@ class DataHandler:
                                                                snapshot.input_npy_file))
             tmp_file_name = naming_scheme_input
             tmp_file_name = tmp_file_name.replace("*", str(i))
-            np.save(directory+tmp_file_name+".npy", tmp_array)
+            np.save(os.path.join(directory, tmp_file_name) +".npy", tmp_array)
 
             tmp_array = self.__load_from_npy_file(os.path.join(snapshot.output_npy_directory,
                                                                snapshot.output_npy_file))
@@ -550,9 +550,9 @@ class DataHandler:
             for snapshot in self.parameters.snapshot_directories_list:
                 # Data scaling is only performed on the training data sets.
                 if self.parameters.data_splitting_snapshots[i] == "tr":
-                    tmp = self.__load_from_npy_file(snapshot.
-                                                    input_npy_directory +
-                                                    snapshot.input_npy_file,
+                    tmp = self.__load_from_npy_file(os.path.join(snapshot.
+                                                    input_npy_directory,
+                                                    snapshot.input_npy_file),
                                                     mmapmode='r')
                     if self.parameters.descriptors_contain_xyz:
                         tmp = tmp[:, :, :, 3:]
@@ -598,9 +598,9 @@ class DataHandler:
             for snapshot in self.parameters.snapshot_directories_list:
                 # Data scaling is only performed on the training data sets.
                 if self.parameters.data_splitting_snapshots[i] == "tr":
-                    tmp = self.__load_from_npy_file(snapshot.
-                                                    output_npy_directory +
-                                                    snapshot.output_npy_file,
+                    tmp = self.__load_from_npy_file(os.path.join(snapshot.
+                                                    output_npy_directory,
+                                                    snapshot.output_npy_file),
                                                     mmapmode='r')
                     # The scalers will later operate on torch Tensors so we
                     # have to make sure they are fitted on
@@ -636,9 +636,9 @@ class DataHandler:
 
             # Data scaling is only performed on the training data sets.
             if self.parameters.data_splitting_snapshots[i] == "tr":
-                tmp = self.__load_from_npy_file(snapshot.
-                                                input_npy_directory +
-                                                snapshot.input_npy_file,
+                tmp = self.__load_from_npy_file(os.path.join(snapshot.
+                                                input_npy_directory,
+                                                snapshot.input_npy_file),
                                                 mmapmode='r')
                 if self.parameters.descriptors_contain_xyz:
                     tmp = tmp[:, :, :, 3:]
@@ -672,8 +672,9 @@ class DataHandler:
             # Data scaling is only performed on the training data sets.
             if self.parameters.data_splitting_snapshots[i] == "tr":
                 tmp = self. \
-                    __load_from_npy_file(snapshot.output_npy_directory +
-                                         snapshot.output_npy_file,
+                    __load_from_npy_file(os.path.join(
+                                         snapshot.output_npy_directory,
+                                         snapshot.output_npy_file),
                                          mmapmode='r')
                 tmp = np.array(tmp)
                 tmp *= self.target_calculator. \

--- a/mala/descriptors/snap.py
+++ b/mala/descriptors/snap.py
@@ -1,4 +1,6 @@
 """SNAP descriptor class."""
+import os
+
 import warnings
 import ase
 import ase.io
@@ -99,7 +101,8 @@ class SNAP(DescriptorBase):
         self.in_format_ase = "espresso-out"
         print("Calculating SNAP descriptors from", qe_out_file, "at",
               qe_out_directory)
-        return self.__calculate_snap(qe_out_directory + qe_out_file,
+        return self.__calculate_snap(os.path.join(qe_out_directory,
+                                                  qe_out_file),
                                      qe_out_directory)
 
     def __calculate_snap(self, infile, outdir):
@@ -111,7 +114,7 @@ class SNAP(DescriptorBase):
 
         # Enforcing / Checking PBC on the read atoms.
         atoms = self.enforce_pbc(atoms)
-        ase_out_path = outdir+"lammps_input.tmp"
+        ase_out_path = os.path.join(outdir, "lammps_input.tmp")
         ase.io.write(ase_out_path, atoms, format=lammps_format)
 
         # We also need to know how big the grid is.
@@ -135,7 +138,8 @@ class SNAP(DescriptorBase):
                     nz = int(tmp.split(",")[2])
                     break
         # Build LAMMPS arguments from the data we read.
-        lmp_cmdargs = ["-screen", "none", "-log", outdir+"lammps_log.tmp"]
+        lmp_cmdargs = ["-screen", "none", "-log", os.path.join(outdir,
+                                                               "lammps_log.tmp")]
         lmp_cmdargs = set_cmdlinevars(lmp_cmdargs,
                                       {
                                         "ngridx": nx,
@@ -152,7 +156,8 @@ class SNAP(DescriptorBase):
         # An empty string means that the user wants to use the standard input.
         if self.parameters.lammps_compute_file == "":
             filepath = __file__.split("snap")[0]
-            self.parameters.lammps_compute_file = filepath+"in.bgrid.python"
+            self.parameters.lammps_compute_file = os.path.join(filepath,
+                                                               "in.bgrid.python")
 
         # Do the LAMMPS calculation.
         lmp.file(self.parameters.lammps_compute_file)

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -50,7 +50,7 @@ class Density(TargetBase):
             Units the density is saved in. Usually none.
         """
         printout("Reading density from .cube file in ", directory)
-        data, meta = read_cube(directory + file_name)
+        data, meta = read_cube(os.path.join(directory, file_name))
         return data
 
     def get_number_of_electrons(self, density_data, grid_spacing_bohr=None,

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -1,4 +1,6 @@
 """DOS calculation class."""
+import os
+
 from .target_base import TargetBase
 from .calculation_helpers import *
 from scipy import integrate, interpolate
@@ -107,7 +109,7 @@ class DOS(TargetBase):
         return_dos_values = []
 
         # Open the file, then iterate through its contents.
-        with open(directory+file_name, 'r') as infile:
+        with open(os.path.join(directory, file_name), 'r') as infile:
             lines = infile.readlines()
             i = 0
 

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -1,4 +1,6 @@
 """LDOS calculation class."""
+import os
+
 from .cube_parser import read_cube
 from .target_base import TargetBase
 from .calculation_helpers import *
@@ -134,7 +136,7 @@ class LDOS(TargetBase):
             tmp_file_name = tmp_file_name.replace("*", str(i).zfill(digits))
 
             # Open the cube file
-            data, meta = read_cube(directory + tmp_file_name)
+            data, meta = read_cube(os.path.join(directory, tmp_file_name))
 
             # Once we have read the first cube file, we know the dimensions
             # of the LDOS and can prepare the array


### PR DESCRIPTION
Paths should be joined using os.path.join() or tools from pathlib. Using
string concatenation is error-prone. For instance, DataHandler code
breaks if paths don't end in "/". I'm sure there is more, only fixed
what bit me.

Closes #195