### PR TITLE
bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,11 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True
+sign_tags = True
+
+[bumpversion:file:mala/version.py]
+
+[bumpversion:file:CITATION.cff]
+
+[bumpversion:file:Copyright.txt]

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ with open("LICENSE") as f:
     license = f.read()
 
 extras = {
+    'dev': ['bump2version'],
     'opt': ['oapackage'],
     'test': ['pytest'],
     'doc': open('docs/requirements.txt').read().splitlines(),


### PR DESCRIPTION
I've tested the config file, everything works as expected:

```sh
$ bumpversion minor
```

updates the version number in `mala/version.py` (and  with that in `setup.py`), `CITATION.cff` and `Copyright.txt` from `0.1.0` to `0.2.0`.