### PR TITLE
Updated data repo paths in tests and examples

### DIFF
--- a/examples/ex01_run_singleshot.py
+++ b/examples/ex01_run_singleshot.py
@@ -1,8 +1,10 @@
+import os
+
 import mala
 from mala import printout
 
-from data_repo_path import get_data_repo_path
-data_path = get_data_repo_path()+"Al36/"
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
 
 """
 ex01_run_singleshot.py: Shows how a neural network can be trained on material 

--- a/examples/ex02_preprocess_data.py
+++ b/examples/ex02_preprocess_data.py
@@ -1,9 +1,10 @@
+import os
+
 import mala
 from mala import printout
 
-from data_repo_path import get_data_repo_path
-import numpy as np
-data_path = get_data_repo_path()+"Be2/"
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Be2")
 
 """
 ex02_preprocess_data.py: Shows how this framework can be used to preprocess

--- a/examples/ex03_postprocess_data.py
+++ b/examples/ex03_postprocess_data.py
@@ -1,9 +1,11 @@
+import os
+
 import mala
 from mala import printout
 import numpy as np
 
-from data_repo_path import get_data_repo_path
-data_path = get_data_repo_path()+"Be2/"
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Be2")
 
 
 """
@@ -46,12 +48,12 @@ ldos = mala.TargetInterface(test_parameters)
 # Read additional information about the calculation.
 # By doing this, the calculator is able to know e.g. the temperature
 # at which the calculation took place or the lattice constant used.
-ldos.read_additional_calculation_data("qe.out",
-                                      data_path+"Be.pw.scf.out")
+ldos.read_additional_calculation_data("qe.out", os.path.join(
+                                      data_path, "Be.pw.scf.out"))
 
 # Read in LDOS data. For actual workflows, this part will come
 # from a network.
-ldos_data = np.load(data_path+"Be_ldos.npy")
+ldos_data = np.load(os.path.join(data_path, "Be_ldos.npy"))
 
 # Get quantities of interest.
 # For better values in the post processing, it is recommended to

--- a/examples/ex04_hyperparameter_optimization.py
+++ b/examples/ex04_hyperparameter_optimization.py
@@ -1,8 +1,10 @@
+import os
+
 import mala
 from mala import printout
 
-from data_repo_path import get_data_repo_path
-data_path = get_data_repo_path()+"Al36/"
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
 
 """
 ex04_hyperparameter_optimization.py: Shows how a hyperparameter 

--- a/examples/ex05_training_with_postprocessing.py
+++ b/examples/ex05_training_with_postprocessing.py
@@ -1,8 +1,11 @@
+import os
+
 import mala
 from mala import printout
 
-from data_repo_path import get_data_repo_path
-data_path = get_data_repo_path()+"Al36/"
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
+
 """
 ex05_training_with_postprocessing.py: Train a network, then use this network 
 to predict the LDOS and then analyze the results of this prediction. This 
@@ -62,9 +65,9 @@ def use_trained_network(network_path, params_path, input_scaler_path,
 
     # We will use the LDOS calculator to do some preprocessing.
     ldos_calculator = inference_data_handler.target_calculator
-    ldos_calculator.read_additional_calculation_data("qe.out",
-                                                     data_path +
-                                                     "Al.pw.scf.out")
+    ldos_calculator.read_additional_calculation_data("qe.out", os.path.join(
+                                                     data_path,
+                                                     "Al.pw.scf.out"))
 
     # Calculate the Band energy.
     band_energy_predicted = ldos_calculator.get_band_energy(predicted_ldos)

--- a/examples/ex06_advanced_hyperparameter_optimization.py
+++ b/examples/ex06_advanced_hyperparameter_optimization.py
@@ -1,8 +1,10 @@
+import os
+
 import mala
 from mala import printout
 
-from data_repo_path import get_data_repo_path
-data_path = get_data_repo_path()+"Al36/"
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
 
 """
 ex06_advanced_hyperparameter_optimization.py: Shows how recent developments 

--- a/examples/ex07_checkpoint_training.py
+++ b/examples/ex07_checkpoint_training.py
@@ -1,8 +1,10 @@
+import os
+
 import mala
 from mala import printout
 
-from data_repo_path import get_data_repo_path
-data_path = get_data_repo_path()+"Al36/"
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
 
 """
 ex07_checkpoint_training.py: Shows how a training run can be paused and 

--- a/examples/ex08_checkpoint_hyperopt.py
+++ b/examples/ex08_checkpoint_hyperopt.py
@@ -1,8 +1,10 @@
+import os
+
 import mala
 from mala import printout
 
-from data_repo_path import get_data_repo_path
-data_path = get_data_repo_path()+"Al36/"
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
 
 """
 ex08_checkpoint_hyperopt.py: Shows how a hyperparameter optimization run can 

--- a/examples/ex09_distributed_hyperopt.py
+++ b/examples/ex09_distributed_hyperopt.py
@@ -2,10 +2,9 @@ import os
 
 import mala
 from mala import printout
-import numpy as np
 
-from data_repo_path import get_data_repo_path
-data_path = get_data_repo_path()+"Al36/"
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
 
 """
 ex09_distributed_hyperopt.py: Shows how a hyperparameter 

--- a/examples/ex10_tensor_board.py
+++ b/examples/ex10_tensor_board.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import webbrowser
 
@@ -5,8 +6,8 @@ import mala
 from mala import printout
 from tensorboard import program
 
-from data_repo_path import get_data_repo_path
-data_path = get_data_repo_path()+"Al36/"
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
 
 
 """

--- a/install/data_repo_link/link_data_repo.sh
+++ b/install/data_repo_link/link_data_repo.sh
@@ -38,10 +38,6 @@ fi
 rm -f ${script_path}/${pythonfile}
 touch ${script_path}/${pythonfile}
 echo "data_repo_path = \"${data_repo_path}\""   >> ${script_path}/${pythonfile}
-echo "" >> ${script_path}/${pythonfile}
-echo "" >> ${script_path}/${pythonfile}
-echo "def get_data_repo_path():"   >> ${script_path}/${pythonfile}
-echo "    return data_repo_path"   >> ${script_path}/${pythonfile}
 
 # copy the file to test and example folders.
 cp ${script_path}/${pythonfile} ${test_path}

--- a/mala/datahandling/lazy_load_dataset.py
+++ b/mala/datahandling/lazy_load_dataset.py
@@ -1,4 +1,6 @@
 """DataSet for lazy-loading."""
+import os
+
 try:
     import horovod.torch as hvd
 except ModuleNotFoundError:
@@ -134,11 +136,13 @@ class LazyLoadDataset(torch.utils.data.Dataset):
         """
         # Load the data into RAM.
         self.input_data = \
-            np.load(self.snapshot_list[file_index].input_npy_directory +
-                    self.snapshot_list[file_index].input_npy_file)
+            np.load(os.path.join(
+                    self.snapshot_list[file_index].input_npy_directory,
+                    self.snapshot_list[file_index].input_npy_file))
         self.output_data = \
-            np.load(self.snapshot_list[file_index].output_npy_directory +
-                    self.snapshot_list[file_index].output_npy_file)
+            np.load(os.path.join(
+                    self.snapshot_list[file_index].output_npy_directory,
+                    self.snapshot_list[file_index].output_npy_file))
 
         # Transform the data.
         if self.descriptors_contain_xyz:

--- a/test/basic_gpu_test.py
+++ b/test/basic_gpu_test.py
@@ -19,8 +19,8 @@ import numpy as np
 import pytest
 import torch
 
-from data_repo_path import get_data_repo_path
-data_path = os.path.join(get_data_repo_path(), "Al36/")
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
 
 test_checkpoint_name = "test"
 

--- a/test/checkpoint_hyperopt_tests.py
+++ b/test/checkpoint_hyperopt_tests.py
@@ -4,9 +4,9 @@ import mala
 from mala import printout
 import numpy as np
 
-from data_repo_path import get_data_repo_path
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
 
-data_path = os.path.join(get_data_repo_path(), "Al36/")
 checkpoint_name = "test_ho"
 
 # Define the accuracy used in the tests.

--- a/test/checkpoint_training_tests.py
+++ b/test/checkpoint_training_tests.py
@@ -4,9 +4,9 @@ import mala
 from mala import printout
 import numpy as np
 
-from data_repo_path import get_data_repo_path
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
 test_checkpoint_name = "test"
-data_path = os.path.join(get_data_repo_path(), "Al36/")
 
 # Define the accuracy used in the tests.
 accuracy = 1e-14

--- a/test/hyperopt_test.py
+++ b/test/hyperopt_test.py
@@ -3,9 +3,8 @@ import os
 import mala
 import numpy as np
 
-from data_repo_path import get_data_repo_path
-
-data_path = os.path.join(get_data_repo_path(), "Al36/")
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
 
 # Control how much the loss should be better after hyperopt compared to
 # before. This value is fairly high, but we're training on absolutely

--- a/test/inference_test.py
+++ b/test/inference_test.py
@@ -3,9 +3,9 @@ import os
 import numpy as np
 from mala import Parameters, DataHandler, DataScaler, Network, Tester
 
-from data_repo_path import get_data_repo_path
-data_path = os.path.join(get_data_repo_path(), "Al36/")
-param_path = os.path.join(get_data_repo_path(), "workflow_test/")
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
+param_path = os.path.join(data_repo_path, "workflow_test/")
 params_path = param_path+"workflow_test_params.pkl"
 network_path = param_path+"workflow_test_network.pth"
 input_scaler_path = param_path+"workflow_test_iscaler.pkl"
@@ -43,12 +43,12 @@ class TestInference:
         inference_data_handler.prepare_data()
 
         # Confirm that unit conversion does not introduce any errors.
+
         from_file_1 = inference_data_handler.target_calculator.\
-            convert_units(np.load(data_path+"Al_debug_2k_nr"+str(0) +
-                                  ".out.npy"), in_units="1/Ry")
-        from_file_2 = np.load(data_path+"Al_debug_2k_nr"+str(0) +
-                              ".out.npy")*inference_data_handler.\
-            target_calculator.convert_units(1, in_units="1/Ry")
+            convert_units(np.load(os.path.join(data_path, "Al_debug_2k_nr" + str(0) + ".out.npy")),
+                          in_units="1/Ry")
+        from_file_2 = np.load(os.path.join(data_path, "Al_debug_2k_nr" + str(0) + ".out.npy"))\
+            * inference_data_handler.target_calculator.convert_units(1, in_units="1/Ry")
 
         assert from_file_1.sum() == from_file_2.sum()
 
@@ -124,12 +124,11 @@ class TestInference:
         # Compare actual_ldos with file directly.
         # This is the only comparison that counts.
         from_file = inference_data_handler.target_calculator.\
-            convert_units(np.load(data_path+"Al_debug_2k_nr" +
-                                  str(0)+".out.npy"), in_units="1/Ry")
+            convert_units(np.load(os.path.join(data_path, "Al_debug_2k_nr" + str(0)+".out.npy")),
+                          in_units="1/Ry")
 
         # Test if prediction still works.
-        raw_predicted_outputs = np.load(data_path+"Al_debug_2k_nr"+str(0) +
-                                        ".in.npy")
+        raw_predicted_outputs = np.load(os.path.join(data_path, "Al_debug_2k_nr" + str(0) + ".in.npy"))
         raw_predicted_outputs = inference_data_handler.\
             raw_numpy_to_converted_scaled_tensor(raw_predicted_outputs,
                                                  "in", "None")

--- a/test/installation_test.py
+++ b/test/installation_test.py
@@ -24,8 +24,8 @@ class TestInstallation:
 
     def test_data_repo(self):
         """Test whether the data repo is set up properly"""
-        from data_repo_path import get_data_repo_path
-        data_path = get_data_repo_path()
-        test_array = np.load(os.path.join(data_path, "linking_tester.npy"))
+        from data_repo_path import data_repo_path
+        test_array = np.load(os.path.join(data_repo_path,
+                                          "linking_tester.npy"))
         assert np.array_equal(test_array, [1, 2, 3, 4])
         

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -6,7 +6,7 @@ import numpy as np
 import scipy as sp
 import pytest
 
-from data_repo_path import get_data_repo_path
+from data_repo_path import data_repo_path
 
 # In order to test the integration capabilities of MALA we need a
 # QuantumEspresso
@@ -18,7 +18,7 @@ from data_repo_path import get_data_repo_path
 # Scripts to reproduce the data files used in this test script can be found
 # in the data repo.
 
-data_path = os.path.join(get_data_repo_path(), "Be2")
+data_path = os.path.join(data_repo_path, "Be2")
 path_to_out = os.path.join(data_path, "Be.pw.scf.out")
 path_to_ldos_npy = os.path.join(data_path, "Be_ldos.npy")
 path_to_dos_npy = os.path.join(data_path, "Be_dos.npy")

--- a/test/lazy_loading_test.py
+++ b/test/lazy_loading_test.py
@@ -7,11 +7,12 @@ import numpy as np
 import torch
 import pytest
 
-from data_repo_path import get_data_repo_path
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
+
 # This test compares the data scaling using the regular scaling procedure and
 # the lazy-loading one (incremental fitting).
 
-data_path = os.path.join(get_data_repo_path(), "Al36/")
 accuracy_strict = 1e-3
 accuracy_coarse = 1e-3
 

--- a/test/tensor_memory.py
+++ b/test/tensor_memory.py
@@ -5,8 +5,9 @@ import torch
 from torch.utils.data import TensorDataset
 from torch.utils.data import DataLoader
 
-from data_repo_path import get_data_repo_path
-data_path = os.path.join(get_data_repo_path(), "Al36")
+from data_repo_path import data_repo_path
+data_path = os.path.join(data_repo_path, "Al36")
+
 # Define the accuracy used in the tests.
 accuracy = 1e-5
 


### PR DESCRIPTION
Updates data repo path. In the process, the tests now all include paths without trailing "/" and also I think I now found all the ugly string concats; Thus this PR closes #197 as well as #194 . 