### PR TITLE
Change auth mechanism for deploy steps in workflows

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -82,7 +82,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: mala-project/test-data
-          token: ${{ secrets.ACCESS_TOKEN }}
           path: mala_data
           ref: v1.0.0
           lfs: false

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -1,6 +1,8 @@
 name: CPU
 
 on:
+  pull_request_review:
+    types: [submitted,edited]
   pull_request:
     branches:
       - master
@@ -43,6 +45,7 @@ jobs:
         run: docker build . --file Dockerfile --tag $IMAGE_NAME --cache-from=$IMAGE_ID --build-arg DEVICE=cpu --label "runnumber=${GITHUB_RUN_ID}"
 
       - name: Push image
+        if: ${{ github.event.review.state == 'approved' || github.event_name == 'push' }}
         run: |
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
@@ -93,4 +96,3 @@ jobs:
 
       - name: Test MALA
         run: pytest --disable-warnings
-        

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,6 +1,8 @@
 name: docs
 
 on:
+  pull_request_review:
+    types: [submitted,edited]
   pull_request:
     branches:
       - master
@@ -58,7 +60,8 @@ jobs:
           mv -v docs/_build/html public
 
       - name: Deploy
+        if: ${{ github.event.review.state == 'approved' || github.event_name == 'push' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./public


### PR DESCRIPTION
We change from using `GITHUB_TOKEN` to a ssh-key pair to enable PRs from forks to actually deploy our GitHub pages - but only when reviewed and approved by members with privilges (maintainer, owner) of mala.

We remove `ACCESS_TOKEN` as is it is no longer needed to access the `test-data` repository (it became public).
