### PR TITLE
Fix build docker images workflow

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -1,14 +1,12 @@
 name: CPU
 
 on:
-  pull_request_review:
-    types: [submitted,edited]
   pull_request:
+    # triggered on pull requests to main or develop
     branches:
       - master
       - develop
-
-    # Publish `v1.2.3` tags as releases.
+  push:
     tags:
       - v*
 

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -43,22 +43,22 @@ jobs:
         run: docker build . --file Dockerfile --tag $IMAGE_NAME --cache-from=$IMAGE_ID --build-arg DEVICE=cpu --label "runnumber=${GITHUB_RUN_ID}"
 
       - name: Push image
-        if: ${{ github.event.review.state == 'approved' || github.event_name == 'push' }}
         run: |
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # print github.ref contexts (for debugging)
+          echo github.ref = "${{ github.ref }}"
+          echo github.ref_name = "${{ github.ref_name }}"
 
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # use Docker `x.x.x` tag for push tag events (set Docker tag to git version tag and strip "v" prefix from tag)
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && TAG=$(echo "${{ github.ref_name }}" | sed -e 's/^v//')
 
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "develop" ] && VERSION=latest
+          # use Docker `latest` tag for pull requests
+          [[ "${{ github.ref }}" == "refs/pull/"*"/merge" ]] && TAG=latest
 
           echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
+          echo TAG=$TAG
 
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$TAG
+          docker push $IMAGE_ID:$TAG
 
   cpu-tests:
     needs: build-docker-image-cpu

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -2,11 +2,14 @@ name: CPU
 
 on:
   pull_request:
-    # triggered on pull requests to main or develop
+    # triggered on pull requests to master or develop
     branches:
       - master
       - develop
   push:
+    branches:
+      - master
+      - develop
     tags:
       - v*
 
@@ -42,17 +45,17 @@ jobs:
       - name: Build image
         run: docker build . --file Dockerfile --tag $IMAGE_NAME --cache-from=$IMAGE_ID --build-arg DEVICE=cpu --label "runnumber=${GITHUB_RUN_ID}"
 
-      - name: Push image
+      - name: Tag and push image
         run: |
           # print github.ref contexts (for debugging)
           echo github.ref = "${{ github.ref }}"
           echo github.ref_name = "${{ github.ref_name }}"
 
+          # use Docker `latest` tag for pull requests and pushes without a git tag (default)
+          TAG=latest
+
           # use Docker `x.x.x` tag for push tag events (set Docker tag to git version tag and strip "v" prefix from tag)
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && TAG=$(echo "${{ github.ref_name }}" | sed -e 's/^v//')
-
-          # use Docker `latest` tag for pull requests
-          [[ "${{ github.ref }}" == "refs/pull/"*"/merge" ]] && TAG=latest
 
           echo IMAGE_ID=$IMAGE_ID
           echo TAG=$TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM continuumio/miniconda3:4.9.2
 
-# Choose 'cpu' or 'gpu'
-ARG DEVICE=cpu
-
 # Update the image to the latest packages
 RUN apt-get --allow-releaseinfo-change update && apt-get upgrade -y
 
 RUN apt-get install --no-install-recommends -y build-essential libz-dev swig git-lfs
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Choose 'cpu' or 'gpu'
+ARG DEVICE=cpu
 COPY install/mala_${DEVICE}_environment.yml .
 RUN conda env create -f mala_${DEVICE}_environment.yml && rm -rf /opt/conda/pkgs/*
 


### PR DESCRIPTION
This PR closes #254 and

- fixes/enables caching of Docker layers while building Docker image
- uses `latest` or `x.x.x` tag as Docker tags depending on trigger events (PR, git tag push, push to `master` or `develop`)
- is a first improvement on when to build and how to tag Docker images

Currently, the build process only runs successfully when one of the trigger events is triggered by a member/owner/maintainer from within the MALA repository. A PR from a forked repository is not allowed to push the Docker image built in the workflow to the container registry and fails with the message
```
denied: installation not allowed to Write organization package
Error: Process completed with exit code 1.
```
We need to clarify in a separate issue how the Docker build/push process of PRs should be handled when they come from a fork.