### PR TITLE
Add optional MALA dependencies to Docker image:

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install mala package
         run: |
           pip --no-cache-dir install -e .
-          pip install oapackage==2.6.8
+          pip install oapackage
           pip install pytest
       - name: Check out repository (data)
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
-FROM continuumio/miniconda3:4.9.2
+FROM continuumio/miniconda3:latest
 
 # Update the image to the latest packages
 RUN apt-get --allow-releaseinfo-change update && apt-get upgrade -y
 
-RUN apt-get install --no-install-recommends -y build-essential libz-dev swig git-lfs
+RUN apt-get install --no-install-recommends -y build-essential libz-dev swig git-lfs cmake
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Choose 'cpu' or 'gpu'
 ARG DEVICE=cpu
 COPY install/mala_${DEVICE}_environment.yml .
 RUN conda env create -f mala_${DEVICE}_environment.yml && rm -rf /opt/conda/pkgs/*
+
+# Install optional MALA dependencies into Conda environment with pip
+RUN /opt/conda/envs/mala-${DEVICE}/bin/pip install --no-input --no-cache-dir pytest oapackage pqkmeans
 
 RUN echo "source activate mala-${DEVICE}" > ~/.bashrc
 ENV PATH /opt/conda/envs/mala-${DEVICE}/bin:$PATH


### PR DESCRIPTION
Adding `pytest`, `oapackage` and `pqkmeans` avoids installing these
packages within each CI run which is rather time consuming.

At least `oapackage` is not installable via Conda, one has to use `pip`
instead. In order to install those packages inside the `mala-cpu` or
`mala-gpu` environment one has to use the `pip` binary from inside these
conda environments. Usually one would do

```sh
$ conda activate mala-cpu
(mala-cpu)$ pip install oapackage
```

An alternative way is to directly use the `pip` binary from the
environment.

CMake is a dependency of `pqkmeans`. Finally, we are forced to switch to
the `latest` basis image which is based on Debian 11 and comes with a
recent SWIG version (4.0.2) needed for `oapackage`.