### PR TITLE
Add test to CPU workflow

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -77,9 +77,25 @@ jobs:
 
       - name: Install mala package
         run: |
+          # epxort Docker image Conda environment for a later comparison
+          conda env export -n mala-cpu > env_1.yml
+
+          # install mala package
           pip --no-cache-dir install -e .
+
+          # install extra dependencies
           pip install oapackage
           pip install pytest
+
+      - name: Check if Conda environment meets the specified requirements
+        run: |
+          # export Conda environment _with_ mala package installed in it (and extra dependencies)
+          conda env export -n mala-cpu > env_2.yml
+
+          # if comparison fails, `install/mala_cpu_[base]_environment.yml` needs to be aligned with
+          # `requirements.txt` and/or extra dependencies are missing in the Docker Conda environment
+          diff env_1.yml env_2.yml
+
       - name: Check out repository (data)
         uses: actions/checkout@v2
         with:
@@ -88,5 +104,5 @@ jobs:
           ref: v1.3.0
           lfs: false
 
-      - name: Test MALA
+      - name: Test mala
         run: MALA_DATA_REPO=$(pwd)/mala_data pytest --disable-warnings


### PR DESCRIPTION
Adds a check if the Conda environment aligns with the dependencies in the `requirements.txt`. If dependencies were added to `requirments.txt`, but were forgotten to be added to the Conda environment, then this test would fail and signal a misalignment between Conda environment in the Docker image and Mala's dependencies (and pssoible extra dependencies).