### PR TITLE
Reactivate sphinx' viewcode extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
-#    'sphinx.ext.viewcode',
+    'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
 ]
 


### PR DESCRIPTION
Since we have long been public, we can reactivate the `viewcode` extension again, which allows to jump to the code from within the docs.