### PR TITLE
Using make apidocs also in the GH workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build API and docs
         run: |
-          make apidocs
+          make -C docs apidocs
           sphinx-build -W --keep-going -b html -d docs/_build/doctrees docs/source docs/_build/html
           mv -v docs/_build/html public
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build API and docs
         run: |
-          sphinx-apidoc -o docs/source/api mala
+          make apidocs
           sphinx-build -W --keep-going -b html -d docs/_build/doctrees docs/source docs/_build/html
           mv -v docs/_build/html public
 


### PR DESCRIPTION
With this we only have one place to maintain for the API docs. 