### PR TITLE
MALA on Windows

### DIFF
--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,26 @@
+@echo off
+
+SET SOURCEDIR=source
+SET BUILDDIR=_build
+@REM Should be equivalent to the ?= in the Makefile
+IF "%SPHINXBUILD%"=="" (SET SPHINXBUILD=sphinx-build)
+@REM We currently don't have any other SPHINXOPTS
+@REM IF "%SPHINXOPTS%"=="" (SET SPHINXOPTS=)
+
+IF /I "%1"=="help" GOTO help
+IF /I "%1"=="apidocs" GOTO apidocs
+
+@REM Instead of the % from the Makefile, this should do the same
+GOTO default
+
+:help
+	@%SPHINXBUILD% -M help "%SOURCEDIR%" "%BUILDDIR%" %SPHINXOPTS% %O%
+	GOTO :EOF
+
+:default
+	@%SPHINXBUILD% -M "%1" "%SOURCEDIR%" "%BUILDDIR%" %SPHINXOPTS% %O%
+	GOTO :EOF
+
+:apidocs
+	sphinx-apidoc --templatedir=source/templates -e -d 6 -f -o source/api ../mala
+	GOTO :EOF

--- a/docs/source/install/README.md
+++ b/docs/source/install/README.md
@@ -147,10 +147,10 @@ $ pip install -r docs/requirements.txt
 ```
 
 1. Change into `docs/` folder.
-2. Run `make apidocs`.
-3. Run `make html`. This creates a `_build` folder inside `docs`. You may also want to use `make html SPHINXOPTS="-W"` sometimes. This treats warnings as errors and stops the output at first occurence of an error (useful for debugging rST syntax).
+2. Run `make apidocs` on Linux/macOS or `.\make.bat apidocs` on Windows.
+3. Run `make html` on Linux/macOS or `.\make.bat html` on Windows. This creates a `_build` folder inside `docs`. You may also want to use `make html SPHINXOPTS="-W"` sometimes. This treats warnings as errors and stops the output at first occurence of an error (useful for debugging rST syntax).
 4. Open `docs/_build/html/index.html`.
-5. `make clean` if required (e.g. after fixing erros) and building again
+5. Run `make clean` on Linux/macOS or `.\make.bat clean` on Windows. if required (e.g. after fixing erros) and building again
 
 
 ## Downloading and adding example data

--- a/docs/source/install/tested_systems.rst
+++ b/docs/source/install/tested_systems.rst
@@ -41,6 +41,21 @@ macOS
   * python version: 3.8.5
   * Installation successful: Not tested
 
+
+Windows
+----------
+* Windows 10
+* OS Version: 10.0.19044 Build 19044
+* pip:
+  * pip version: 3.8.10
+  * Installation successful: Yes
+* conda:
+
+  * Installation successful: Not tested
+* LAMMPS: Not tested
+* Quantum Espresso: Not tested
+
+
 HPC clusters
 ***************
 Hemera5 (CentOS)

--- a/mala/network/network.py
+++ b/mala/network/network.py
@@ -240,7 +240,6 @@ class FeedForwardNet(Network):
                 else:
                     self.layers.append(self.activation_mappings[self.params.
                                        layer_activations[i]]())
-                print(self.layers[-1])
             except KeyError:
                 raise Exception("Invalid activation type seleceted.")
 

--- a/test/hyperopt_test.py
+++ b/test/hyperopt_test.py
@@ -1,4 +1,5 @@
 import os
+import importlib
 
 import mala
 import numpy as np
@@ -85,8 +86,13 @@ class TestHyperparameterOptimization:
 
     def test_different_ho_methods(self):
         results = [self.__optimize_hyperparameters("optuna"),
-                   self.__optimize_hyperparameters("oat"),
                    self.__optimize_hyperparameters("naswot")]
+
+        # Since the OApackage is optional, we should only run
+        # it if it is actually there.
+        if importlib.util.find_spec("oapackage") is not None:
+            results.append(
+                   self.__optimize_hyperparameters("oat"))
 
         assert np.std(results) < desired_std_ho
 


### PR DESCRIPTION
The installation itself is trivial, as the default MALA installation only needs a few readily available packages, and puts everything else in the hand of the user. 
I had to alter one test, because through writing this I realized that `oapackage` was required for the test suite to run, which should not be the case. 
I also created a `make.bat` so the documentation may be built locally on Windows. 
Tested on a recent Windows 10. 

Closes #56 .