### PR TITLE
Reverting OApackage to 2.6.8, so that miniconda3:4.9.2 can be used again

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -154,8 +154,12 @@ jobs:
           # epxort Docker image Conda environment for a later comparison
           conda env export -n mala-cpu > env_1.yml
 
+          # Manually install oapackage because we are bound to a certain
+          # version currently
+          pip install oapackage==2.6.8
+
           # install mala package
-          pip --no-cache-dir install -e .[opt,test]
+          pip --no-cache-dir install -e .[test]
 
       - name: Check if Conda environment meets the specified requirements
         shell: 'bash -c "docker exec -i mala-cpu bash < {0}"'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:latest
+FROM continuumio/miniconda3:4.9.2
 
 # Update the image to the latest packages
 RUN apt-get --allow-releaseinfo-change update && apt-get upgrade -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY install/mala_${DEVICE}_environment.yml .
 RUN conda env create -f mala_${DEVICE}_environment.yml && rm -rf /opt/conda/pkgs/*
 
 # Install optional MALA dependencies into Conda environment with pip
-RUN /opt/conda/envs/mala-${DEVICE}/bin/pip install --no-input --no-cache-dir pytest oapackage pqkmeans
+RUN /opt/conda/envs/mala-${DEVICE}/bin/pip install --no-input --no-cache-dir pytest oapackage==2.6.8 pqkmeans
 
 RUN echo "source activate mala-${DEVICE}" > ~/.bashrc
 ENV PATH /opt/conda/envs/mala-${DEVICE}/bin:$PATH


### PR DESCRIPTION
I was wrong about OAPackage 2.6.8 not working. It does. So we can fix #265 by downgrading oapackage safely. 