### PR TITLE
Add workflow for publishing on PyPI and TestPyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,59 @@
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+    tags:
+      - 'v*.*.*'
+  release:
+    types:
+      - published
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish distribution 📦 to TestPyPI
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+        verbose: true
+        # When a release gets created out of a tag (see next step), *this* step is triggered
+        # again and would cause an error due to the already exsiting tag on TestPyPI. Setting
+        # skip_existing to true avoids the pipeline to fail because of this.
+        skip_existing: true
+
+    - name: Publish distribution 📦 to PyPI
+      if: github.event_name == 'release'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        verbose: true
+

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This repository is structured as follows:
 
 ## Installation
 
+> **WARNING**: Even if you install MALA via PyPI, please consult the full installation instructions afterwards. External modules (like the QuantumESPRESSO bindings) are not distributed via PyPI!
+
 Please refer to [Installation of MALA](docs/source/install/README.md).
 
 ## Running

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras = {
 }
 
 setup(
-    name="mala",
+    name="pymala",
     version=version["__version__"],
     description=("Materials Learning Algorithms. "
                  "A framework for machine learning materials properties from "


### PR DESCRIPTION
I've added secrets `TEST_PYPI_API_TOKEN` and `PYPI_API_TOKEN` to the mala settings.

On pushes to `master` and `develop` this workflow gets triggered and tries to build the mala package. On tags being pushed, the package will also be uploaded to TestPyPI. Only when a tag is turned into a release via GitHub, the package is published on PyPI.