### PR TITLE
Added new factory methods and caching algorithms

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -28,7 +28,8 @@ jobs:
         run: pip install -qU pydocstyle
 
       - name: Check docstrings
-        run: pydocstyle --convention=numpy mala
+         # Ignoring the cached_properties because pydocstyle (sometimes?) treats them as functions.
+        run: pydocstyle --convention=numpy --ignore-decorators=cached_property mala
 
   build-and-deploy-pages:
     needs: test-docstrings

--- a/docs/source/usage/postprocessing.rst
+++ b/docs/source/usage/postprocessing.rst
@@ -4,7 +4,18 @@ Postprocessing the LDOS
 MALA provides routines to calculate quantities of interests from the physical
 data such as the LDOS, DOS and electronic density. The latter are not directly
 predicted by MALA. In practice, they are either obtained via the LDOS, or
-come directly from a DFT calculation. Basic postprocessing can be done via
+come directly from a DFT calculation. MALA implements two ways of accessing
+observables and derived quantities from ab-initio data.
+
+Cached access (recommended)
+---------------------------
+
+Mala `Target` objects provide several properties corresponding to physical
+quantities. If a Target object is set up to contain electronic structure data,
+then accessing properties will calculate them if needed, and provide cached
+values if not. This method of access is preferred as it ensures consistency
+and efficiency.
+For example, one can do:
 
       .. code-block:: python
 
@@ -13,15 +24,45 @@ come directly from a DFT calculation. Basic postprocessing can be done via
             parameters = mala.Parameters()
             parameters.targets.descriptor_type = 'LDOS'
 
-            # Creates a LDOS object via interface
-            ldos = mala.Target(parameters)
+            # Creates a LDOS object directly.
+            # This object will contain LDOS data.
+            ldos = mala.LDOS.from_cube_file(parameters, path_to_cube_fiöle)
 
-            # Creates a LDOS object directly
+            # The first command will calculate the Fermi energy because it
+            # has not been calculated yet. In the second command, the band
+            # energy will be calculated, and the cached Fermi energy will
+            # be used for that.
+            fermi_energy = ldos.fermi_energy
+            band_energy = ldos.band_energy
+
+            # Uncaching the properties makes it possible to have them be
+            # calculated anew (because e.g. temperatures have changed)
+            ldos.uncache_properties()
+
+A wider range of properties is available, see e.g. ``ex03_postprocess_data``.
+For a full list, consult the API reference.
+
+Direct access
+-------------
+
+For direct access to properties several `get_some_property()` functions exist.
+They offer a more fine-granular access to several calculation parameters,
+but put efficiency and consistency in the users hands. Usage is similar to
+the cached access:
+
+      .. code-block:: python
+
+            import mala
+
+            parameters = mala.Parameters()
+            parameters.targets.descriptor_type = 'LDOS'
+
+            # Creates a LDOS object directly, without data.
             ldos = mala.LDOS(parameters)
 
-            # Use the LDOS object to calculate the band energy from LDOS data.
-            ldos_data = ldos.read_from_cube(...)
-            band_energy = ldos.get_band_energy(ldos_data)
+            # To perform calculations, one now has to read in data first.
+            ldos.read_from_cube(...)
 
-But a wider range of properties is available, see e.g. ``ex03_postprocess_data``.
-For a full list, consult the API reference.
+            # Use the LDOS object to calculate the band energy from LDOS data.
+            # Several keyword arguments are possible here.
+            band_energy = ldos.get_band_energy(ldos.ldos, ....)

--- a/examples/ex02_preprocess_data.py
+++ b/examples/ex02_preprocess_data.py
@@ -51,9 +51,9 @@ data_converter = mala.DataConverter(test_parameters)
 
 # Take care to choose the "add_snapshot" function correct for
 # the type of data you want to preprocess.
-data_converter.add_snapshot_qeout_cube("Be.pw.scf.out", data_path,
-                                       "cubes/tmp.pp*Be_ldos.cube",
-                                       data_path, output_units="1/Ry")
+data_converter.add_snapshot_qeout_cube(os.path.join(data_path, "Be.pw.scf.out"),
+                                       os.path.join(data_path, "cubes/tmp.pp*Be_ldos.cube"),
+                                       output_units="1/Ry")
 
 # Convert all the snapshots and save them in the current directory.
 data_converter.convert_snapshots("./", naming_scheme="Be_snapshot*")

--- a/examples/ex03_postprocess_data.py
+++ b/examples/ex03_postprocess_data.py
@@ -45,17 +45,16 @@ test_parameters.targets.pseudopotential_path = data_path
 # Create a target calculator to postprocess data.
 # Use this calculator to perform various operations.
 ####################
-ldos = mala.Target(test_parameters)
+# Read in LDOS data. For actual workflows, this part will come
+# from a network.
+ldos = mala.LDOS.from_numpy_file(test_parameters,
+                                 os.path.join(data_path, "Be_ldos.npy"))
 
 # Read additional information about the calculation.
 # By doing this, the calculator is able to know e.g. the temperature
 # at which the calculation took place or the lattice constant used.
 ldos.read_additional_calculation_data("qe.out", os.path.join(
                                       data_path, "Be.pw.scf.out"))
-
-# Read in LDOS data. For actual workflows, this part will come
-# from a network.
-ldos_data = np.load(os.path.join(data_path, "Be_ldos.npy"))
 
 # Get quantities of interest.
 # For better values in the post processing, it is recommended to
@@ -64,19 +63,12 @@ ldos_data = np.load(os.path.join(data_path, "Be_ldos.npy"))
 # This Fermi energy usually differs from the one outputted by the
 # QuantumEspresso calculation, due to numerical reasons. The difference
 # is usually very small.
-self_consistent_fermi_energy = ldos.\
-    get_self_consistent_fermi_energy_ev(ldos_data)
-number_of_electrons = ldos.\
-    get_number_of_electrons(ldos_data, fermi_energy_eV=
-                            self_consistent_fermi_energy)
-band_energy = ldos.get_band_energy(ldos_data,
-                                   fermi_energy_eV=
-                                   self_consistent_fermi_energy)
+self_consistent_fermi_energy = ldos.fermi_energy
+band_energy = ldos.band_energy
+number_of_electrons = ldos.number_of_electrons
 total_energy = 0.0
 if do_total_energy:
-    total_energy = ldos.get_total_energy(ldos_data,
-                                         fermi_energy_eV=
-                                         self_consistent_fermi_energy)
+    total_energy = ldos.total_energy
 
 ####################
 # RESULTS.

--- a/examples/ex03_postprocess_data.py
+++ b/examples/ex03_postprocess_data.py
@@ -93,7 +93,7 @@ if do_total_energy:
     print("Total energy:", total_energy)
 
 print("Values from DFT: ")
-print("Number of electrons:", ldos.number_of_electrons)
+print("Number of electrons:", ldos.number_of_electrons_exact)
 print("Band energy:", ldos.band_energy_dft_calculation)
 if do_total_energy:
     print("Total energy:", ldos.total_energy_dft_calculation)

--- a/examples/ex12_run_predictions.py
+++ b/examples/ex12_run_predictions.py
@@ -52,7 +52,7 @@ def use_predictor(new_network, new_parameters, iscaler, oscaler):
     # Fermi energy has to be calculated self-consistently for predictions,
     # and for that we also have to tell the calculator how many electrons
     # the system has and at which temperature we perform calculations.
-    ldos_calculator.number_of_electrons = 4
+    ldos_calculator.number_of_electrons_exact = 4
     ldos_calculator.temperature_K = 298
 
     fermi_energy = ldos_calculator.get_self_consistent_fermi_energy_ev(ldos)

--- a/mala/datahandling/data_converter.py
+++ b/mala/datahandling/data_converter.py
@@ -54,8 +54,7 @@ class DataConverter:
         self.__snapshot_description = []
         self.__snapshot_units = []
 
-    def add_snapshot_qeout_cube(self, qe_out_file, qe_out_directory,
-                                cube_naming_scheme, cube_directory,
+    def add_snapshot_qeout_cube(self, qe_out_file, cube_files_scheme,
                                 input_units=None, output_units=None):
         """
         Add a Quantum Espresso snapshot to the list of conversion list.
@@ -70,14 +69,8 @@ class DataConverter:
         qe_out_file : string
             Name of Quantum Espresso output file for this snapshot.
 
-        qe_out_directory : string
-            Path to Quantum Espresso output file for this snapshot.
-
-        cube_naming_scheme : string
+        cube_files_scheme : string
             Naming scheme for the LDOS .cube files.
-
-        cube_directory : string
-            Directory containing the LDOS .cube files.
 
         input_units : string
             Unit of the input data.
@@ -85,9 +78,7 @@ class DataConverter:
         output_units : string
             Unit of the output data.
         """
-        self.__snapshots_to_convert.append([qe_out_file, qe_out_directory,
-                                            cube_naming_scheme,
-                                            cube_directory])
+        self.__snapshots_to_convert.append([qe_out_file, cube_files_scheme])
         self.__snapshot_description.append(["qe.out", ".cube"])
         self.__snapshot_units.append([input_units, output_units])
 
@@ -137,11 +128,10 @@ class DataConverter:
         if description[0] == "qe.out":
             if original_units[0] is None:
                 tmp_input, local_size = self.descriptor_calculator. \
-                    calculate_from_qe_out(snapshot[0], snapshot[1])
+                    calculate_from_qe_out(snapshot[0])
             else:
                 tmp_input, local_size = self.descriptor_calculator. \
-                    calculate_from_qe_out(snapshot[0], snapshot[1],
-                                          units=original_units[0])
+                    calculate_from_qe_out(snapshot[0])
             if self.parameters._configuration["mpi"]:
                 tmp_input = self.descriptor_calculator.gather_descriptors(tmp_input)
 
@@ -166,11 +156,11 @@ class DataConverter:
 
             # If no units are provided we just assume standard units.
             if original_units[1] is None:
-                tmp_output = self.target_calculator.read_from_cube(
-                    snapshot[2], snapshot[3], use_memmap=use_memmap)
+                tmp_output = self.target_calculator.\
+                    read_from_cube(snapshot[1], use_memmap=use_memmap)
             else:
                 tmp_output = self.target_calculator. \
-                    read_from_cube(snapshot[2], snapshot[3], units=
+                    read_from_cube(snapshot[1], units=
                 original_units[1], use_memmap=use_memmap)
         else:
             raise Exception(

--- a/mala/datahandling/data_converter.py
+++ b/mala/datahandling/data_converter.py
@@ -6,7 +6,10 @@ import numpy as np
 from mala.common.parallelizer import printout, get_rank
 from mala.common.parameters import ParametersData
 from mala.descriptors.descriptor import Descriptor
+from mala.targets.density import Density
+from mala.targets.ldos import LDOS
 from mala.targets.target import Target
+
 
 
 class DataConverter:
@@ -156,12 +159,13 @@ class DataConverter:
 
             # If no units are provided we just assume standard units.
             if original_units[1] is None:
-                tmp_output = self.target_calculator.\
+                self.target_calculator.\
                     read_from_cube(snapshot[1], use_memmap=use_memmap)
             else:
-                tmp_output = self.target_calculator. \
+                self.target_calculator. \
                     read_from_cube(snapshot[1], units=
                 original_units[1], use_memmap=use_memmap)
+            tmp_output = self.target_calculator.get_target()
         else:
             raise Exception(
                 "Unknown file extension, cannot convert target"

--- a/mala/descriptors/descriptor.py
+++ b/mala/descriptors/descriptor.py
@@ -144,7 +144,7 @@ class Descriptor(ABC):
         return new_atoms
 
     @abstractmethod
-    def calculate_from_qe_out(self, qe_out_file, qe_out_directory):
+    def calculate_from_qe_out(self, qe_out_file):
         """
         Calculate the descriptors based on a Quantum Espresso outfile.
 
@@ -153,8 +153,6 @@ class Descriptor(ABC):
         qe_out_file : string
             Name of Quantum Espresso output file for snapshot.
 
-        qe_out_directory : string
-            Path to Quantum Espresso output file for snapshot.
 
         Returns
         -------

--- a/mala/descriptors/snap.py
+++ b/mala/descriptors/snap.py
@@ -90,7 +90,7 @@ class SNAP(Descriptor):
         else:
             raise Exception("Unsupported unit for SNAP.")
 
-    def calculate_from_qe_out(self, qe_out_file, qe_out_directory):
+    def calculate_from_qe_out(self, qe_out_file, working_directory="."):
         """
         Calculate the SNAP descriptors based on a Quantum Espresso outfile.
 
@@ -99,8 +99,10 @@ class SNAP(Descriptor):
         qe_out_file : string
             Name of Quantum Espresso output file for snapshot.
 
-        qe_out_directory : string
-            Path to Quantum Espresso output file for snapshot.
+        working_directory : string
+            A directory in which to write the output of the LAMMPS calculation.
+            Usually the local directory should suffice, given that there
+            are no multiple instances running in the same directory.
 
         Returns
         -------
@@ -110,17 +112,15 @@ class SNAP(Descriptor):
 
         """
         self.in_format_ase = "espresso-out"
-        printout("Calculating SNAP descriptors from", qe_out_file, "at",
-                 qe_out_directory, min_verbosity=0)
+        printout("Calculating SNAP descriptors from", qe_out_file, min_verbosity=0)
         # We get the atomic information by using ASE.
-        infile = os.path.join(qe_out_directory, qe_out_file)
-        atoms = ase.io.read(infile, format=self.in_format_ase)
+        atoms = ase.io.read(qe_out_file, format=self.in_format_ase)
 
         # Enforcing / Checking PBC on the read atoms.
         atoms = self.enforce_pbc(atoms)
 
         # Get the grid dimensions.
-        qe_outfile = open(infile, "r")
+        qe_outfile = open(qe_out_file, "r")
         lines = qe_outfile.readlines()
         nx = 0
         ny = 0
@@ -134,8 +134,7 @@ class SNAP(Descriptor):
                 nz = int(tmp.split(",")[2])
                 break
 
-        return self.__calculate_snap(atoms,
-                                     qe_out_directory, [nx, ny, nz])
+        return self.__calculate_snap(atoms, working_directory, [nx, ny, nz])
 
     def calculate_from_atoms(self, atoms, grid_dimensions,
                              working_directory="."):
@@ -151,7 +150,9 @@ class SNAP(Descriptor):
             Grid dimensions to be used, in the format [x,y,z].
 
         working_directory : string
-            A directory in which to perform the LAMMPS calculation.
+            A directory in which to write the output of the LAMMPS calculation.
+            Usually the local directory should suffice, given that there
+            are no multiple instances running in the same directory.
 
         Returns
         -------

--- a/mala/interfaces/ase_calculator.py
+++ b/mala/interfaces/ase_calculator.py
@@ -123,7 +123,7 @@ class MALA(Calculator):
             fermi_energy_ev = dos_calculator.get_self_consistent_fermi_energy_ev(
                 dos)
             density = ldos_calculator.get_density(ldos,
-                                                  fermi_energy_ev=fermi_energy_ev)
+                                                  fermi_energy_eV=fermi_energy_ev)
             energy, self.last_energy_contributions = ldos_calculator.\
             get_total_energy(dos_data=dos, density_data=density,
                              fermi_energy_eV=fermi_energy_ev,

--- a/mala/interfaces/ase_calculator.py
+++ b/mala/interfaces/ase_calculator.py
@@ -115,8 +115,8 @@ class MALA(Calculator):
         if get_rank() == 0:
             # Define calculator objects.
             ldos_calculator: LDOS = self.data_handler.target_calculator
-            density_calculator = Density.from_ldos(ldos_calculator)
-            dos_calculator = DOS.from_ldos(ldos_calculator)
+            density_calculator = Density.from_ldos_calculator(ldos_calculator)
+            dos_calculator = DOS.from_ldos_calculator(ldos_calculator)
 
             # Get DOS and density.
             dos = ldos_calculator.get_density_of_states(ldos, gather_dos=False)

--- a/mala/network/predictor.py
+++ b/mala/network/predictor.py
@@ -175,7 +175,7 @@ class Predictor(Runner):
             local_data_size = self.data.grid_size
         predicted_outputs = np.zeros((local_data_size,
                                       self.data.target_calculator.\
-                                      get_feature_size()))
+                                      feature_size))
 
         # Only predict if there is something to predict.
         # Elsewise, we just wait at the barrier down below.

--- a/mala/network/predictor.py
+++ b/mala/network/predictor.py
@@ -101,6 +101,9 @@ class Predictor(Runner):
         predicted_ldos : numpy.array
             Precicted LDOS for these atomic positions.
         """
+        # Make sure no data lingers in the target calculator.
+        self.data.target_calculator.invalidate_target()
+
         # Calculate SNAP descriptors.
         snap_descriptors, local_size = self.data.descriptor_calculator.\
             calculate_from_atoms(atoms, self.data.grid_dimension)

--- a/mala/network/runner.py
+++ b/mala/network/runner.py
@@ -73,10 +73,10 @@ class Runner:
 
         Returns
         -------
-        actual_outputs : torch.Tensor
+        actual_outputs : numpy.ndarray
             Actual outputs for snapshot.
 
-        predicted_outputs : torch.Tensor
+        predicted_outputs : numpy.ndarray
             Precicted outputs for snapshot.
         """
         if self.data.parameters.use_lazy_loading:

--- a/mala/network/tester.py
+++ b/mala/network/tester.py
@@ -46,12 +46,15 @@ class Tester(Runner):
 
         Returns
         -------
-        actual_outputs : torch.Tensor
+        actual_outputs : numpy.ndarray
             Actual outputs for snapshot.
 
-        predicted_outputs : torch.Tensor
+        predicted_outputs : numpy.ndarray
             Precicted outputs for snapshot.
         """
+        # Make sure no data lingers in the target calculator.
+        self.data.target_calculator.invalidate_target()
+
         # Forward through network.
         return self.\
             _forward_entire_snapshot(snapshot_number,

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -132,7 +132,7 @@ class Density(Target):
         return_density_object.fermi_energy_dft = ldos_object.fermi_energy_dft
         return_density_object.temperature_K = ldos_object.temperature_K
         return_density_object.voxel_Bohr = ldos_object.voxel_Bohr
-        return_density_object.number_of_electrons = ldos_object.\
+        return_density_object.number_of_electrons_exact = ldos_object.\
             number_of_electrons_exact
         return_density_object.band_energy_dft_calculation = ldos_object.\
             band_energy_dft_calculation
@@ -193,7 +193,7 @@ class Density(Target):
         due to discretization errors.
         """
         if self.density is not None:
-            return self.get_number_of_electrons(density_data=self.density)
+            return self.get_number_of_electrons()
         else:
             raise Exception("No cached density available to "
                             "calculate this property.")
@@ -206,7 +206,7 @@ class Density(Target):
         Calculated via the cached density.
         """
         if self.density is not None:
-            return self.get_energy_contributions(density_data=self.density)
+            return self.get_energy_contributions()
         else:
             raise Exception("No cached density available to "
                             "calculate this property.")

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -183,14 +183,14 @@ class Density(Target):
         """
         self.density = np.load(path)
 
-    def read_from_array(self, array, units="1/eV"):
+    def read_from_array(self, array, units=None):
         """
         Read the density data from a numpy array.
 
         Parameters
         ----------
         array : numpy.ndarray
-            Name of the numpy file.
+            Numpy array containing the density..
 
         units : string
             Units the density is saved in. Usually none.

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -27,7 +27,7 @@ class Density(Target):
         Parameters used to create this Target object.
     """
     ##############################
-    # Global attributes
+    # Class attributes
     ##############################
 
     te_mutex = False
@@ -43,7 +43,7 @@ class Density(Target):
     @classmethod
     def from_numpy(cls, params, path):
         return_density_object = Density(params)
-        return_density_object.density = np.load(path)
+        return_density_object.density.read_from_numpy(path)
         return return_density_object
 
     @classmethod
@@ -70,7 +70,7 @@ class Density(Target):
 
         """
         return_density_object = Density(ldos_object.parameters)
-        return_density_object.fermi_energy_eV = ldos_object.fermi_energy_eV
+        return_density_object.fermi_energy_dft = ldos_object.fermi_energy_dft
         return_density_object.temperature_K = ldos_object.temperature_K
         return_density_object.voxel_Bohr = ldos_object.voxel_Bohr
         return_density_object.number_of_electrons = ldos_object.\
@@ -105,6 +105,11 @@ class Density(Target):
         # properties.
         self.uncache_properties()
 
+    @property
+    def feature_size(self):
+        """Get dimension of this target if used as feature in ML."""
+        return 1
+
     @cached_property
     def number_of_electrons(self):
         if self.density is not None:
@@ -132,7 +137,6 @@ class Density(Target):
     ##############################
     # Methods
     ##############################
-
 
     # File I/O
     ##########
@@ -213,10 +217,6 @@ class Density(Target):
 
     # Calculations
     ##############
-
-    def get_feature_size(self):
-        """Get dimension of this target if used as feature in ML."""
-        return 1
 
     def get_number_of_electrons(self, density_data, voxel_Bohr=None,
                                 integration_method="summation"):

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -117,6 +117,10 @@ class Density(Target):
         # properties.
         self.uncache_properties()
 
+    def get_target(self):
+        """Generic interface for cached target quantities."""
+        return self.density
+
     @property
     def feature_size(self):
         """Get dimension of this target if used as feature in ML."""

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -179,6 +179,15 @@ class Density(Target):
         """
         return self.density
 
+    def invalidate_target(self):
+        """
+        Invalidates the saved target wuantity.
+
+        This is the generic interface for cached target quantities.
+        It should work for all implemented targets.
+        """
+        self.density = None
+
     @property
     def feature_size(self):
         """Get dimension of this target if used as feature in ML."""

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -26,6 +26,7 @@ class Density(Target):
     params : mala.common.parameters.Parameters
         Parameters used to create this Target object.
     """
+
     ##############################
     # Class attributes
     ##############################
@@ -42,18 +43,69 @@ class Density(Target):
 
     @classmethod
     def from_numpy_file(cls, params, path):
+        """
+        Create a Density calculator from a numpy array saved in a file.
+
+        Parameters
+        ----------
+        params : mala.common.parameters.Parameters
+            Parameters used to create this LDOS object.
+
+        path : string
+            Path to file that is being read.
+
+        Returns
+        -------
+        dens_object : mala.targets.density.Density
+            Density calculator object.
+        """
         return_density_object = Density(params)
         return_density_object.density.read_from_numpy(path)
         return return_density_object
 
     @classmethod
     def from_numpy_array(cls, params, array):
+        """
+        Create a Density calculator from a numpy array in memory.
+
+        By using this function rather then setting the density
+        object directly, proper unit coversion is ensured.
+
+        Parameters
+        ----------
+        params : mala.common.parameters.Parameters
+            Parameters used to create this LDOS object.
+
+        array : numpy.ndarray
+            Path to file that is being read.
+
+        Returns
+        -------
+        dens_object : mala.targets.density.Density
+            Density calculator object.
+        """
         return_dos = Density(params)
         return_dos.read_from_array(array)
         return return_dos
 
     @classmethod
     def from_cube_file(cls, params, path):
+        """
+        Create a Density calculator from a cube file.
+
+        Parameters
+        ----------
+        params : mala.common.parameters.Parameters
+            Parameters used to create this DOS object.
+
+        path : string
+            Name of the cube file.
+
+        Returns
+        -------
+        dens_object : mala.targets.density.Density
+            Density object created from LDOS object.
+        """
         return_density_object = Density(params)
         return_density_object.read_from_cube(path)
         return return_density_object
@@ -61,7 +113,10 @@ class Density(Target):
     @classmethod
     def from_ldos_calculator(cls, ldos_object):
         """
-        Create a density object from an LDOS object.
+        Create a Density calculator from an LDOS object.
+
+        If the LDOS object has data associated with it, this data will
+        be copied.
 
         Parameters
         ----------
@@ -70,10 +125,8 @@ class Density(Target):
 
         Returns
         -------
-        dos_object : Density
+        dens_object : mala.targets.density.Density
             Density object created from LDOS object.
-
-
         """
         return_density_object = Density(ldos_object.parameters)
         return_density_object.fermi_energy_dft = ldos_object.fermi_energy_dft
@@ -118,7 +171,12 @@ class Density(Target):
         self.uncache_properties()
 
     def get_target(self):
-        """Generic interface for cached target quantities."""
+        """
+        Get the target quantity.
+
+        This is the generic interface for cached target quantities.
+        It should work for all implemented targets.
+        """
         return self.density
 
     @property
@@ -128,6 +186,12 @@ class Density(Target):
 
     @cached_property
     def number_of_electrons(self):
+        """
+        Number of electrons in the system, calculated via cached Density.
+
+        Does not necessarily match up exactly with KS-DFT provided values,
+        due to discretization errors.
+        """
         if self.density is not None:
             return self.get_number_of_electrons(density_data=self.density)
         else:
@@ -136,6 +200,11 @@ class Density(Target):
 
     @cached_property
     def total_energy_contributions(self):
+        """
+        All density based contributions to the total energy.
+
+        Calculated via the cached density.
+        """
         if self.density is not None:
             return self.get_energy_contributions(density_data=self.density)
         else:
@@ -163,7 +232,7 @@ class Density(Target):
 
         Parameters
         ----------
-        path :
+        path : string
             Name of the cube file.
 
         units : string

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -350,7 +350,7 @@ class DOS(Target):
                                    (dos_data, energy_grid,
                                     fermi_sc, temperature_K,
                                     integration_method)
-                                   - self.number_of_electrons),
+                                   - self.number_of_electrons_exact),
                                   a=energy_grid[0],
                                   b=energy_grid[-1])
         return fermi_energy_sc
@@ -380,7 +380,7 @@ class DOS(Target):
         return_dos_object.fermi_energy_eV = ldos_object.fermi_energy_eV
         return_dos_object.temperature_K = ldos_object.temperature_K
         return_dos_object.voxel_Bohr = ldos_object.voxel_Bohr
-        return_dos_object.number_of_electrons = ldos_object.number_of_electrons
+        return_dos_object.number_of_electrons_exact = ldos_object.number_of_electrons_exact
         return_dos_object.band_energy_dft_calculation = \
             ldos_object.band_energy_dft_calculation
         return_dos_object.atoms = ldos_object.atoms

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -210,6 +210,15 @@ class DOS(Target):
         """
         return self.density_of_states
 
+    def invalidate_target(self):
+        """
+        Invalidates the saved target wuantity.
+
+        This is the generic interface for cached target quantities.
+        It should work for all implemented targets.
+        """
+        self.density_of_states = None
+
     @cached_property
     def energy_grid(self):
         """Energy grid on which the DOS is expressed."""
@@ -461,7 +470,9 @@ class DOS(Target):
         units : string
             Units the density is saved in. Usually none.
         """
-        self.density_of_states = array*self.convert_units(1, in_units=units)
+        self.density_of_states = array
+        self.density_of_states *= \
+            self.convert_units(1, in_units=units)
 
     # Calculations
     ##############

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -117,6 +117,10 @@ class DOS(Target):
         # properties.
         self.uncache_properties()
 
+    def get_target(self):
+        """Generic interface for cached target quantities."""
+        return self.density_of_states
+
     @cached_property
     def energy_grid(self):
         return self.get_energy_grid()

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -524,12 +524,11 @@ class DOS(Target):
         band_energy : float
             Band energy in eV.
         """
-        print("Calculating the band energy.")
         # Parse the parameters.
         # Parse the parameters.
         if dos_data is None and self.density_of_states is None:
-                raise Exception("No DOS data provided, cannot calculate"
-                                " this quantity.")
+            raise Exception("No DOS data provided, cannot calculate"
+                            " this quantity.")
 
         # Here we check whether we will use our internal, cached
         # DOS, or calculate everything from scratch.
@@ -581,11 +580,10 @@ class DOS(Target):
         number_of_electrons : float
             Number of electrons.
         """
-        print("Calculating the number of electrons.")
         # Parse the parameters.
         if dos_data is None and self.density_of_states is None:
-                raise Exception("No DOS data provided, cannot calculate"
-                                " this quantity.")
+            raise Exception("No DOS data provided, cannot calculate"
+                            " this quantity.")
 
         # Here we check whether we will use our internal, cached
         # DOS, or calculate everything from scratch.
@@ -696,7 +694,6 @@ class DOS(Target):
         fermi_energy_self_consistent : float
             :math:`\epsilon_F` in eV.
         """
-        print("Calculating the fermi energy.")
         if dos_data is None:
             dos_data = self.density_of_states
             if dos_data is None:

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -508,21 +508,23 @@ class DOS(Target):
         """
         print("Calculating the band energy.")
         # Parse the parameters.
-        if dos_data is None:
-            dos_data = self.density_of_states
-            if dos_data is None:
+        # Parse the parameters.
+        if dos_data is None and self.density_of_states is None:
                 raise Exception("No DOS data provided, cannot calculate"
                                 " this quantity.")
 
-        if fermi_energy_eV is None:
-            if dos_data is None:
-                fermi_energy_eV = self.fermi_energy
+        # Here we check whether we will use our internal, cached
+        # DOS, or calculate everything from scratch.
+        if dos_data is not None:
             if fermi_energy_eV is None:
                 printout("Warning: No fermi energy was provided or could be "
                          "calculated from electronic structure data. "
                          "Using the DFT fermi energy, this may "
                          "yield unexpected results", min_verbosity=1)
-                fermi_energy_eV = self.fermi_energy_dft
+            fermi_energy_eV = self.fermi_energy_dft
+        else:
+            dos_data = self.density_of_states
+            fermi_energy_eV = self.fermi_energy
         if temperature_K is None:
             temperature_K = self.temperature_K
 
@@ -563,21 +565,23 @@ class DOS(Target):
         """
         print("Calculating the number of electrons.")
         # Parse the parameters.
-        if dos_data is None:
-            dos_data = self.density_of_states
-            if dos_data is None:
+        if dos_data is None and self.density_of_states is None:
                 raise Exception("No DOS data provided, cannot calculate"
                                 " this quantity.")
 
-        if fermi_energy_eV is None:
-            if dos_data is None:
-                fermi_energy_eV = self.fermi_energy
+        # Here we check whether we will use our internal, cached
+        # DOS, or calculate everything from scratch.
+        if dos_data is not None:
             if fermi_energy_eV is None:
                 printout("Warning: No fermi energy was provided or could be "
                          "calculated from electronic structure data. "
                          "Using the DFT fermi energy, this may "
                          "yield unexpected results", min_verbosity=1)
-                fermi_energy_eV = self.fermi_energy_dft
+            fermi_energy_eV = self.fermi_energy_dft
+        else:
+            dos_data = self.density_of_states
+            fermi_energy_eV = self.fermi_energy
+
         if temperature_K is None:
             temperature_K = self.temperature_K
         energy_grid = self.energy_grid
@@ -617,21 +621,22 @@ class DOS(Target):
             S/beta in eV.
         """
         # Parse the parameters.
-        if dos_data is None:
-            dos_data = self.density_of_states
-            if dos_data is None:
+        if dos_data is None and self.density_of_states is None:
                 raise Exception("No DOS data provided, cannot calculate"
                                 " this quantity.")
 
-        if fermi_energy_eV is None:
-            if dos_data is None:
-                fermi_energy_eV = self.fermi_energy
+        # Here we check whether we will use our internal, cached
+        # DOS, or calculate everything from scratch.
+        if dos_data is not None:
             if fermi_energy_eV is None:
                 printout("Warning: No fermi energy was provided or could be "
                          "calculated from electronic structure data. "
                          "Using the DFT fermi energy, this may "
                          "yield unexpected results", min_verbosity=1)
-                fermi_energy_eV = self.fermi_energy_dft
+            fermi_energy_eV = self.fermi_energy_dft
+        else:
+            dos_data = self.density_of_states
+            fermi_energy_eV = self.fermi_energy
         if temperature_K is None:
             temperature_K = self.temperature_K
 

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -29,7 +29,7 @@ class DOS(Target):
         self.density_of_states = None
 
     @classmethod
-    def from_ldos(cls, ldos_object):
+    def from_ldos_calculator(cls, ldos_object):
         """
         Create a DOS object from an LDOS object.
 
@@ -60,6 +60,11 @@ class DOS(Target):
         return_dos_object.kpoints = ldos_object.kpoints
         return_dos_object.number_of_electrons_from_eigenvals = \
             ldos_object.number_of_electrons_from_eigenvals
+
+        # If the source calculator has LDOS data, then this new object
+        # can have DOS data.
+        if ldos_object.local_density_of_states is not None:
+            return_dos_object.density_of_states = ldos_object.density_of_states
 
         return return_dos_object
 
@@ -329,7 +334,7 @@ class DOS(Target):
 
     def read_from_array(self, array, units="1/eV"):
         """
-        Read the density data from a numpy file.
+        Read the density data from a numpy array.
 
         Parameters
         ----------
@@ -576,8 +581,18 @@ class DOS(Target):
                                   b=energy_grid[-1])
         return fermi_energy_sc
 
-    def get_density_of_states(self, dos_data):
-        """Get the density of states."""
+    def get_density_of_states(self, dos_data=None):
+        """
+        Get the density of states.
+
+        This function currently doesn't do much. In the LDOS and
+        density equivalents of it, certain dimensionality reorderings
+        may happen, this function purely exists for consistency
+        reasons. In the future, that may change. 
+        """
+        if dos_data is None:
+            dos_data = self.density_of_states
+
         return dos_data
 
     # Private methods

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -339,7 +339,7 @@ class DOS(Target):
         Parameters
         ----------
         array : numpy.ndarray
-            Name of the numpy file.
+            Numpy array containing the DOS..
 
         units : string
             Units the density is saved in. Usually none.
@@ -405,7 +405,8 @@ class DOS(Target):
                                 " this quantity.")
 
         if fermi_energy_eV is None:
-            fermi_energy_eV = self.fermi_energy
+            if dos_data is None:
+                fermi_energy_eV = self.fermi_energy
             if fermi_energy_eV is None:
                 printout("Warning: No fermi energy was provided or could be "
                          "calculated from electronic structure data. "
@@ -459,7 +460,8 @@ class DOS(Target):
                                 " this quantity.")
 
         if fermi_energy_eV is None:
-            fermi_energy_eV = self.fermi_energy
+            if dos_data is None:
+                fermi_energy_eV = self.fermi_energy
             if fermi_energy_eV is None:
                 printout("Warning: No fermi energy was provided or could be "
                          "calculated from electronic structure data. "
@@ -512,7 +514,8 @@ class DOS(Target):
                                 " this quantity.")
 
         if fermi_energy_eV is None:
-            fermi_energy_eV = self.fermi_energy
+            if dos_data is None:
+                fermi_energy_eV = self.fermi_energy
             if fermi_energy_eV is None:
                 printout("Warning: No fermi energy was provided or could be "
                          "calculated from electronic structure data. "

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -249,8 +249,15 @@ class DOS(Target):
         from how this quantity is calculated. Calculated via cached DOS.
         """
         if self.density_of_states is not None:
-            return self.\
+            fermi_energy = self.\
                 get_self_consistent_fermi_energy_ev()
+
+            # Now that we have a new Fermi energy, we should uncache the
+            # old number of electrons.
+            if self._is_property_cached("number_of_electrons"):
+                del self.number_of_electrons
+            return fermi_energy
+
         else:
             # The Fermi energy is set to None instead of creating an error.
             # This is because the Fermi energy is used a lot throughout
@@ -521,7 +528,7 @@ class DOS(Target):
                          "calculated from electronic structure data. "
                          "Using the DFT fermi energy, this may "
                          "yield unexpected results", min_verbosity=1)
-            fermi_energy_eV = self.fermi_energy_dft
+                fermi_energy_eV = self.fermi_energy_dft
         else:
             dos_data = self.density_of_states
             fermi_energy_eV = self.fermi_energy
@@ -577,7 +584,7 @@ class DOS(Target):
                          "calculated from electronic structure data. "
                          "Using the DFT fermi energy, this may "
                          "yield unexpected results", min_verbosity=1)
-            fermi_energy_eV = self.fermi_energy_dft
+                fermi_energy_eV = self.fermi_energy_dft
         else:
             dos_data = self.density_of_states
             fermi_energy_eV = self.fermi_energy
@@ -633,7 +640,7 @@ class DOS(Target):
                          "calculated from electronic structure data. "
                          "Using the DFT fermi energy, this may "
                          "yield unexpected results", min_verbosity=1)
-            fermi_energy_eV = self.fermi_energy_dft
+                fermi_energy_eV = self.fermi_energy_dft
         else:
             dos_data = self.density_of_states
             fermi_energy_eV = self.fermi_energy

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -220,7 +220,13 @@ class DOS(Target):
         """
         # Parse the parameters.
         if fermi_energy_eV is None:
-            fermi_energy_eV = self.fermi_energy_eV
+            fermi_energy_eV = self.fermi_energy
+            if fermi_energy_eV is None:
+                printout("Warning: No fermi energy was provided or could be "
+                         "calculated from electronic structure data. "
+                         "Using the DFT fermi energy, this may "
+                         "yield unexpected results", min_verbosity=1)
+                fermi_energy_eV = self.fermi_energy_dft
         if temperature_K is None:
             temperature_K = self.temperature_K
 
@@ -260,7 +266,13 @@ class DOS(Target):
         """
         # Parse the parameters.
         if fermi_energy_eV is None:
-            fermi_energy_eV = self.fermi_energy_eV
+            fermi_energy_eV = self.fermi_energy
+            if fermi_energy_eV is None:
+                printout("Warning: No fermi energy was provided or could be "
+                         "calculated from electronic structure data. "
+                         "Using the DFT fermi energy, this may "
+                         "yield unexpected results", min_verbosity=1)
+                fermi_energy_eV = self.fermi_energy_dft
         if temperature_K is None:
             temperature_K = self.temperature_K
         energy_grid = self.get_energy_grid()
@@ -299,7 +311,13 @@ class DOS(Target):
             S/beta in eV.
         """
         if fermi_energy_eV is None:
-            fermi_energy_eV = self.fermi_energy_eV
+            fermi_energy_eV = self.fermi_energy
+            if fermi_energy_eV is None:
+                printout("Warning: No fermi energy was provided or could be "
+                         "calculated from electronic structure data. "
+                         "Using the DFT fermi energy, this may "
+                         "yield unexpected results", min_verbosity=1)
+                fermi_energy_eV = self.fermi_energy_dft
         if temperature_K is None:
             temperature_K = self.temperature_K
 
@@ -377,7 +395,7 @@ class DOS(Target):
 
         """
         return_dos_object = DOS(ldos_object.parameters)
-        return_dos_object.fermi_energy_eV = ldos_object.fermi_energy_eV
+        return_dos_object.fermi_energy_dft = ldos_object.fermi_energy_dft
         return_dos_object.temperature_K = ldos_object.temperature_K
         return_dos_object.voxel_Bohr = ldos_object.voxel_Bohr
         return_dos_object.number_of_electrons_exact = ldos_object.number_of_electrons_exact

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -63,19 +63,19 @@ class DOS(Target):
         return return_dos_object
 
     @classmethod
-    def from_numpy(cls, params, path):
+    def from_numpy(cls, params, path, units="1/eV"):
         return_density_object = DOS(params)
         return_density_object.density.read_from_numpy(path)
         return return_density_object
 
     @classmethod
-    def from_qe_dos_txt(cls, params, path):
+    def from_qe_dos_txt(cls, params, path, units="1/eV"):
         return_density_object = DOS(params)
         return_density_object.read_from_qe_dos_txt(path)
         return return_density_object
 
     @classmethod
-    def from_qe_out(cls, params, path):
+    def from_qe_out(cls, params, path, units="1/eV"):
         return_density_object = DOS(params)
         return_density_object.read_from_qe_out(path)
         return return_density_object
@@ -116,6 +116,13 @@ class DOS(Target):
             del self.density
         if self._is_property_cached("density_of_states"):
             del self.density_of_states
+
+    ##############################
+    # Methods
+    ##############################
+
+    # File I/O
+    ##########
 
     @staticmethod
     def convert_units(array, in_units="1/eV"):
@@ -174,7 +181,7 @@ class DOS(Target):
         else:
             raise Exception("Unsupported unit for LDOS.")
 
-    def read_from_qe_dos_txt(self, file_name, directory):
+    def read_from_qe_dos_txt(self, file_name, directory, units="1/eV"):
         """
         Read the DOS from a Quantum Espresso generated file.
 

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -149,6 +149,15 @@ class LDOS(Target):
         """
         return self.local_density_of_states
 
+    def invalidate_target(self):
+        """
+        Invalidates the saved target wuantity.
+
+        This is the generic interface for cached target quantities.
+        It should work for all implemented targets.
+        """
+        self.local_density_of_states = None
+
     def uncache_properties(self):
         """Uncache all cached properties of this calculator."""
         if self._is_property_cached("number_of_electrons"):
@@ -486,7 +495,8 @@ class LDOS(Target):
         units : string
             Units the density is saved in. Usually none.
         """
-        self.local_density_of_states = array * \
+        self.local_density_of_states = array
+        self.local_density_of_states *= \
             self.convert_units(1, in_units=units)
 
     # Calculations

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -387,20 +387,23 @@ class LDOS(Target):
                                      energy_integration_method)
 
         # Density based energy contributions (via QE)
-        e_rho_times_v_hxc, e_hartree,  e_xc, e_ewald \
+        density_contributions \
             = density_calculator.\
             get_energy_contributions(density_data, qe_input_data=qe_input_data,
                                      atoms_Angstrom=atoms_Angstrom,
                                      qe_pseudopotentials=qe_pseudopotentials,
                                      create_file=create_qe_file)
-        e_total = e_band + e_rho_times_v_hxc + e_hartree + e_xc + e_ewald +\
+        e_total = e_band + density_contributions["e_rho_times_v_hxc"] + \
+            density_contributions["e_hartree"] + \
+            density_contributions["e_xc"] + \
+            density_contributions["e_ewald"] +\
             e_entropy_contribution
         if return_energy_contributions:
             energy_contribtuons = {"e_band": e_band,
-                                   "e_rho_times_v_hxc": e_rho_times_v_hxc,
-                                   "e_hartree": e_hartree,
-                                   "e_xc": e_xc,
-                                   "e_ewald": e_ewald,
+                                   "e_rho_times_v_hxc": density_contributions["e_rho_times_v_hxc"],
+                                   "e_hartree": density_contributions["e_hartree"],
+                                   "e_xc": density_contributions["e_xc"],
+                                   "e_ewald": density_contributions["e_ewald"],
                                    "e_entropy_contribution":
                                        e_entropy_contribution}
             return e_total, energy_contribtuons

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -37,6 +37,19 @@ class LDOS(Target):
 
     @classmethod
     def from_numpy_file(cls, params, path, units="1/eV"):
+        """
+        Create an LDOS calculator from a
+
+        Parameters
+        ----------
+        params
+        path
+        units
+
+        Returns
+        -------
+
+        """
         return_ldos_object = LDOS(params)
         return_ldos_object.read_from_numpy(path, units=units)
 
@@ -69,6 +82,10 @@ class LDOS(Target):
         # Setting a new LDOS means we have to uncache priorly cached
         # properties.
         self.uncache_properties()
+
+    def get_target(self):
+        """Generic interface for cached target quantities."""
+        return self.local_density_of_states
 
     def uncache_properties(self):
         """Uncache all cached properties of this calculator."""
@@ -163,8 +180,6 @@ class LDOS(Target):
         else:
             raise Exception("No cached LDOS available to calculate this "
                             "property.")
-
-
 
     ##############################
     # Methods

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -979,11 +979,6 @@ class LDOS(Target):
             dimensions.
 
         """
-        if ldos_data is None:
-            ldos_data = self.local_density_of_states
-            if ldos_data is None:
-                raise Exception("No LDOS data provided, cannot calculate"
-                                " this quantity.")
         if fermi_energy_eV is None:
             if ldos_data is None:
                 fermi_energy_eV = self.fermi_energy
@@ -995,6 +990,12 @@ class LDOS(Target):
                 fermi_energy_eV = self.fermi_energy_dft
         if temperature_K is None:
             temperature_K = self.temperature_K
+
+        if ldos_data is None:
+            ldos_data = self.local_density_of_states
+            if ldos_data is None:
+                raise Exception("No LDOS data provided, cannot calculate"
+                                " this quantity.")
 
         ldos_data_shape = np.shape(ldos_data)
         if len(ldos_data_shape) == 2:

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -218,8 +218,14 @@ class LDOS(Target):
         from how this quantity is calculated. Calculated via cached LDOS
         """
         if self.local_density_of_states is not None:
-            return self.\
+            fermi_energy = self. \
                 get_self_consistent_fermi_energy_ev()
+
+            # Now that we have a new Fermi energy, we should uncache the
+            # old number of electrons.
+            if self._is_property_cached("number_of_electrons"):
+                del self.number_of_electrons
+            return fermi_energy
         else:
             # The Fermi energy is set to None instead of creating an error.
             # This is because the Fermi energy is used a lot throughout

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -486,7 +486,7 @@ class LDOS(Target):
         units : string
             Units the density is saved in. Usually none.
         """
-        self.local_density_of_states = np.load(array) * \
+        self.local_density_of_states = array * \
             self.convert_units(1, in_units=units)
 
     # Calculations

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -58,6 +58,7 @@ class LDOS(Target):
         """
         return_ldos_object = LDOS(params)
         return_ldos_object.read_from_numpy(path, units=units)
+        return return_ldos_object
 
     @classmethod
     def from_numpy_array(cls, params, array, units="1/eV"):
@@ -85,6 +86,7 @@ class LDOS(Target):
         """
         return_ldos_object = LDOS(params)
         return_ldos_object.read_from_array(array, units=units)
+        return return_ldos_object
 
     @classmethod
     def from_cube_file(cls, params, path_name_scheme, units="1/eV",
@@ -115,6 +117,7 @@ class LDOS(Target):
         return_ldos_object = LDOS(params)
         return_ldos_object.read_from_cube(path_name_scheme, units=units,
                                           use_memmap=use_memmap)
+        return return_ldos_object
 
     ##############################
     # Properties
@@ -176,7 +179,7 @@ class LDOS(Target):
     def total_energy(self):
         """Total energy of the system, calculated via cached LDOS."""
         if self.local_density_of_states is not None:
-            return self.get_total_energy(ldos_data=self.local_density_of_states)
+            return self.get_total_energy()
         else:
             raise Exception("No cached LDOS available to calculate this "
                             "property.")
@@ -185,7 +188,7 @@ class LDOS(Target):
     def band_energy(self):
         """Band energy of the system, calculated via cached LDOS."""
         if self.local_density_of_states is not None:
-            return self.get_band_energy(ldos_data=self.local_density_of_states)
+            return self.get_band_energy()
         else:
             raise Exception("No cached LDOS available to calculate this "
                             "property.")
@@ -199,7 +202,7 @@ class LDOS(Target):
         due to discretization errors.
         """
         if self.local_density_of_states is not None:
-            return self.get_number_of_electrons(self.local_density_of_states)
+            return self.get_number_of_electrons()
         else:
             raise Exception("No cached LDOS available to calculate this "
                             "property.")
@@ -216,8 +219,7 @@ class LDOS(Target):
         """
         if self.local_density_of_states is not None:
             return self.\
-                get_self_consistent_fermi_energy_ev(
-                    self.local_density_of_states)
+                get_self_consistent_fermi_energy_ev()
         else:
             # The Fermi energy is set to None instead of creating an error.
             # This is because the Fermi energy is used a lot throughout
@@ -229,7 +231,7 @@ class LDOS(Target):
     def density(self):
         """Electronic density as calculated by the cached LDOS."""
         if self.local_density_of_states is not None:
-            return self.get_density(self.local_density_of_states)
+            return self.get_density()
         else:
             raise Exception("No cached LDOS available to calculate this "
                             "property.")
@@ -238,7 +240,7 @@ class LDOS(Target):
     def density_of_states(self):
         """DOS as calculated by the cached LDOS."""
         if self.local_density_of_states is not None:
-            return self.get_density_of_states(self.local_density_of_states)
+            return self.get_density_of_states()
         else:
             raise Exception("No cached LDOS available to calculate this "
                             "property.")
@@ -742,19 +744,17 @@ class LDOS(Target):
         band_energy : float
             Band energy in eV.
         """
-        if ldos_data is None:
-            ldos_data = self.local_density_of_states
-            if ldos_data is None:
-                raise Exception("No LDOS data provided, cannot calculate"
-                                " this quantity.")
-
-        # The band energy is calculated using the DOS.
-        if voxel_Bohr is None:
-            voxel_Bohr = self.voxel_Bohr
+        if ldos_data is None and self.local_density_of_states is None:
+            raise Exception("No LDOS data provided, cannot calculate"
+                            " this quantity.")
 
         # Here we check whether we will use our internal, cached
         # LDOS, or calculate everything from scratch.
         if ldos_data is not None:
+            # The band energy is calculated using the DOS.
+            if voxel_Bohr is None:
+                voxel_Bohr = self.voxel_Bohr
+
             dos_data = self.get_density_of_states(ldos_data, voxel_Bohr,
                                                   integration_method=
                                                   grid_integration_method)
@@ -813,11 +813,9 @@ class LDOS(Target):
         number_of_electrons : float
             Number of electrons.
         """
-        if ldos_data is None:
-            ldos_data = self.local_density_of_states
-            if ldos_data is None:
-                raise Exception("No LDOS data provided, cannot calculate"
-                                " this quantity.")
+        if ldos_data is None and self.local_density_of_states is None:
+            raise Exception("No LDOS data provided, cannot calculate"
+                            " this quantity.")
 
         # Here we check whether we will use our internal, cached
         # LDOS, or calculate everything from scratch.
@@ -889,11 +887,10 @@ class LDOS(Target):
         fermi_energy_self_consistent : float
             :math:`\epsilon_F` in eV.
         """
-        if ldos_data is None:
-            ldos_data = self.local_density_of_states
-            if ldos_data is None:
-                raise Exception("No LDOS data provided, cannot calculate"
-                                " this quantity.")
+        if ldos_data is None and self.local_density_of_states is None:
+            raise Exception("No LDOS data provided, cannot calculate"
+                            " this quantity.")
+
         if ldos_data is not None:
             # The Fermi energy is calculated using the DOS.
             if voxel_Bohr is None:

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -488,8 +488,8 @@ class LDOS(Target):
 
         # Now we can create calculation objects to get the necessary
         # quantities.
-        dos_calculator = DOS.from_ldos(self)
-        density_calculator = Density.from_ldos(self)
+        dos_calculator = DOS.from_ldos_calculator(self)
+        density_calculator = Density.from_ldos_calculator(self)
 
         # With these calculator objects we can calculate all the necessary
         # quantities to construct the total energy.
@@ -585,7 +585,7 @@ class LDOS(Target):
 
         # Once we have the DOS, we can use a DOS object to calculate t
         # he band energy.
-        dos_calculator = DOS.from_ldos(self)
+        dos_calculator = DOS.from_ldos_calculator(self)
         return dos_calculator.\
             get_band_energy(dos_data, fermi_energy_eV=fermi_energy_eV,
                             temperature_K=temperature_K,
@@ -643,7 +643,7 @@ class LDOS(Target):
 
         # Once we have the DOS, we can use a DOS object to calculate the
         # number of electrons.
-        dos_calculator = DOS.from_ldos(self)
+        dos_calculator = DOS.from_ldos_calculator(self)
         return dos_calculator.\
             get_number_of_electrons(dos_data, fermi_energy_eV=fermi_energy_eV,
                                     temperature_K=temperature_K,
@@ -707,7 +707,7 @@ class LDOS(Target):
 
         # Once we have the DOS, we can use a DOS object to calculate the
         # number of electrons.
-        dos_calculator = DOS.from_ldos(self)
+        dos_calculator = DOS.from_ldos_calculator(self)
         return dos_calculator.\
             get_self_consistent_fermi_energy_ev(dos_data,
                                                 temperature_K=temperature_K,

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -142,6 +142,11 @@ class Target(ABC):
     def _is_property_cached(self, property_name):
         return property_name in self.__dict__.keys()
 
+    @abstractmethod
+    def get_target(self):
+        """Generic interface for cached target quantities."""
+        pass
+
     def read_additional_calculation_data(self, data_type, data=""):
         """
         Read in additional input about a calculation.

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -138,6 +138,9 @@ class Target(ABC):
     def qe_input_data(self, value):
         self._qe_input_data = value
 
+    def _is_property_cached(self, property_name):
+        return property_name in self.__dict__.keys()
+
     def read_from_cube(self):
         """Read the quantity from a .cube file."""
         raise Exception("No function defined to read this quantity "

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -152,6 +152,16 @@ class Target(ABC):
         """
         pass
 
+    @abstractmethod
+    def invalidate_target(self):
+        """
+        Invalidates the saved target wuantity.
+
+        This is the generic interface for cached target quantities.
+        It should work for all implemented targets.
+        """
+        pass
+
     def read_additional_calculation_data(self, data_type, data=""):
         """
         Read in additional input about a calculation.

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -144,7 +144,12 @@ class Target(ABC):
 
     @abstractmethod
     def get_target(self):
-        """Generic interface for cached target quantities."""
+        """
+        Get the target quantity.
+
+        This is the generic interface for cached target quantities.
+        It should work for all implemented targets.
+        """
         pass
 
     def read_additional_calculation_data(self, data_type, data=""):

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -142,55 +142,6 @@ class Target(ABC):
     def _is_property_cached(self, property_name):
         return property_name in self.__dict__.keys()
 
-    def read_from_cube(self):
-        """Read the quantity from a .cube file."""
-        raise Exception("No function defined to read this quantity "
-                        "from a .cube file.")
-
-    def read_from_qe_dos_txt(self):
-        """Read the quantity from a Quantum Espresso .dos.txt file."""
-        raise Exception("No function defined to read this quantity "
-                        "from a qe.dos.txt file")
-
-    def write_as_cube(self):
-        """Write the quantity in a cube file."""
-        raise Exception("No function defined to write this quantity "
-                        "to a .cube file.")
-
-    def density(self):
-        """The electronic density."""
-        raise Exception("No function to calculate or provide the "
-                        "density has been implemented for this target type.")
-
-    def get_density(self):
-        """Get the electronic density."""
-        raise Exception("No function to calculate or provide the "
-                        "density has been implemented for this target type.")
-
-    def get_density_of_states(self):
-        """Get the density of states."""
-        raise Exception("No function to calculate or provide the"
-                        "density of states (DOS) has been implemented "
-                        "for this target type.")
-
-    def get_band_energy(self):
-        """Get the band energy."""
-        raise Exception("No function to calculate or provide the"
-                        "band energy has been implemented for this target "
-                        "type.")
-
-    def get_number_of_electrons(self):
-        """Get the number of electrons."""
-        raise Exception("No function to calculate or provide the number of"
-                        " electrons has been implemented for this target "
-                        "type.")
-
-    def get_total_energy(self):
-        """Get the total energy."""
-        raise Exception("No function to calculate or provide the number "
-                        "of electons has been implemented for this target "
-                        "type.")
-
     def read_additional_calculation_data(self, data_type, data=""):
         """
         Read in additional input about a calculation.
@@ -353,10 +304,6 @@ class Target(ABC):
 
         else:
             raise Exception("Unsupported auxiliary file type.")
-
-    def get_energy_grid(self):
-        """Get energy grid."""
-        raise Exception("No method implement to calculate an energy grid.")
 
     def get_real_space_grid(self):
         """Get the real space grid."""

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -138,8 +138,8 @@ class TestMALAIntegration:
         # Calculate the quantities we want to compare.
         self_consistent_fermi_energy = ldos_calculator.\
             get_self_consistent_fermi_energy_ev(ldos_dft)
-        density_mala = ldos_calculator.\
-            get_density(ldos_dft, fermi_energy_ev=self_consistent_fermi_energy)
+        density_mala = ldos_calculator. \
+            get_density(ldos_dft, fermi_energy_eV=self_consistent_fermi_energy)
         density_mala_sum = density_mala.sum()
         density_dft_sum = density_dft.sum()
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -109,7 +109,7 @@ class TestMALAIntegration:
 
         # Calculate the quantities we want to compare.
         nr_mala = dens_calculator.get_number_of_electrons(density_dft)
-        nr_dft = dens_calculator.number_of_electrons
+        nr_dft = dens_calculator.number_of_electrons_exact
 
         # Calculate relative error.
         rel_error = np.abs(nr_mala-nr_dft) / nr_dft
@@ -187,7 +187,8 @@ class TestMALAIntegration:
         dos_from_pp = np.load(path_to_dos_npy)
 
         # Calculate the quantities we want to compare.
-        dos_from_dft = dos_calculator.read_from_qe_out()
+        dos_calculator.read_from_qe_out()
+        dos_from_dft = dos_calculator.density_of_states
         dos_pp_sum = dos_from_pp.sum()
         dos_dft_sum = dos_from_dft.sum()
         rel_error = np.abs(dos_dft_sum-dos_pp_sum) / dos_pp_sum

--- a/test/parallel_run_test.py
+++ b/test/parallel_run_test.py
@@ -58,3 +58,7 @@ class TestParallel:
                serial_shape[3] == parallel_shape[3]
         assert np.isclose(np.sum(snaps_serial), np.sum(snaps_parallel),
                           atol=accuracy_snaps)
+
+
+tester = TestParallel()
+tester.test_parallel_descriptors()

--- a/test/parallel_run_test.py
+++ b/test/parallel_run_test.py
@@ -58,7 +58,3 @@ class TestParallel:
                serial_shape[3] == parallel_shape[3]
         assert np.isclose(np.sum(snaps_serial), np.sum(snaps_parallel),
                           atol=accuracy_snaps)
-
-
-tester = TestParallel()
-tester.test_parallel_descriptors()

--- a/test/workflow_test.py
+++ b/test/workflow_test.py
@@ -54,9 +54,8 @@ class TestFullWorkflow:
 
         # Create a DataConverter, and add snapshots to it.
         data_converter = mala.DataConverter(test_parameters)
-        data_converter.add_snapshot_qeout_cube(os.path.join(data_path_ldos,
-                                                            "Be.pw.scf.out"),
-                                               os.path.join(data_path_ldos, "cubes",
+        data_converter.add_snapshot_qeout_cube("Be.pw.scf.out",
+                                               os.path.join("cubes",
                                                             "tmp.pp*Be_ldos.cube"),
                                                output_units="1/Ry")
 

--- a/test/workflow_test.py
+++ b/test/workflow_test.py
@@ -54,8 +54,8 @@ class TestFullWorkflow:
 
         # Create a DataConverter, and add snapshots to it.
         data_converter = mala.DataConverter(test_parameters)
-        data_converter.add_snapshot_qeout_cube("Be.pw.scf.out",
-                                               os.path.join("cubes",
+        data_converter.add_snapshot_qeout_cube(os.path.join(data_path_ldos,"Be.pw.scf.out"),
+                                               os.path.join(data_path_ldos, "cubes",
                                                             "tmp.pp*Be_ldos.cube"),
                                                output_units="1/Ry")
 

--- a/test/workflow_test.py
+++ b/test/workflow_test.py
@@ -54,9 +54,9 @@ class TestFullWorkflow:
 
         # Create a DataConverter, and add snapshots to it.
         data_converter = mala.DataConverter(test_parameters)
-        data_converter.add_snapshot_qeout_cube("Be.pw.scf.out", data_path_ldos,
-                                               os.path.join("cubes", "tmp.pp*Be_ldos.cube"),
-                                               data_path_ldos,
+        data_converter.add_snapshot_qeout_cube("Be.pw.scf.out",
+                                               os.path.join("cubes",
+                                                            "tmp.pp*Be_ldos.cube"),
                                                output_units="1/Ry")
 
         data_converter.convert_snapshots("./", naming_scheme="Be_snapshot*")

--- a/test/workflow_test.py
+++ b/test/workflow_test.py
@@ -164,7 +164,7 @@ class TestFullWorkflow:
                                               data_path_ldos, "Be.pw.scf.out"))
         dos_data = np.load(os.path.join(data_path_ldos, "Be_dos.npy"))
         dens_data = np.load(os.path.join(data_path_ldos, "Be_dens.npy"))
-        dos = mala.DOS.from_ldos(ldos)
+        dos = mala.DOS.from_ldos_calculator(ldos)
 
         # Calculate energies
         self_consistent_fermi_energy = dos. \

--- a/test/workflow_test.py
+++ b/test/workflow_test.py
@@ -102,7 +102,7 @@ class TestFullWorkflow:
                                           fermi_energy_eV=
                                           self_consistent_fermi_energy)
 
-        assert np.isclose(number_of_electrons, dos.number_of_electrons,
+        assert np.isclose(number_of_electrons, dos.number_of_electrons_exact,
                           atol=accuracy_electrons)
         assert np.isclose(band_energy, dos.band_energy_dft_calculation,
                           atol=accuracy_band_energy)
@@ -138,7 +138,7 @@ class TestFullWorkflow:
                                            fermi_energy_eV=
                                            self_consistent_fermi_energy)
 
-        assert np.isclose(number_of_electrons, ldos.number_of_electrons,
+        assert np.isclose(number_of_electrons, ldos.number_of_electrons_exact,
                           atol=accuracy_electrons)
         assert np.isclose(band_energy, ldos.band_energy_dft_calculation,
                           atol=accuracy_band_energy)

--- a/test/workflow_test.py
+++ b/test/workflow_test.py
@@ -54,8 +54,9 @@ class TestFullWorkflow:
 
         # Create a DataConverter, and add snapshots to it.
         data_converter = mala.DataConverter(test_parameters)
-        data_converter.add_snapshot_qeout_cube("Be.pw.scf.out",
-                                               os.path.join("cubes",
+        data_converter.add_snapshot_qeout_cube(os.path.join(data_path_ldos,
+                                                            "Be.pw.scf.out"),
+                                               os.path.join(data_path_ldos, "cubes",
                                                             "tmp.pp*Be_ldos.cube"),
                                                output_units="1/Ry")
 


### PR DESCRIPTION
This PR provides several factory methods for observables and adds functionality to cache intermediate results (e.g. the number of electrons, Fermi energy). It enhances speed and usability. As a (very small) downside, the standard way of accessing calculators is thus now very streamlined, i.e., if you use LDOS.number_of_electrons rather then LDOS.get_number_of_electrons(...) values like temperature, voxel dimensions, etc. will be assumed to be internally correct. This is the case in 99.9% of use cases though, so no big deal.

Before merging I have to do a full scale test on some production level data and update the docs. The bare functionality (save bugs, although the CI reports no errors at the moment) is there however. 

Closes #308 