### PR TITLE
Reduced MALA import time

### DIFF
--- a/mala/common/parallelizer.py
+++ b/mala/common/parallelizer.py
@@ -3,10 +3,6 @@ try:
     import horovod.torch as hvd
 except ModuleNotFoundError:
     pass
-try:
-    from mpi4py import MPI
-except ModuleNotFoundError:
-    pass
 import platform
 from collections import defaultdict
 import torch
@@ -72,6 +68,8 @@ def set_mpi_status(new_value):
     global use_mpi
     use_mpi = new_value
     if use_mpi:
+        from mpi4py import MPI
+
         global comm
         comm = MPI.COMM_WORLD
 

--- a/mala/common/parameters.py
+++ b/mala/common/parameters.py
@@ -10,10 +10,6 @@ try:
     import horovod.torch as hvd
 except ModuleNotFoundError:
     pass
-try:
-    from mpi4py import MPI
-except ModuleNotFoundError:
-    pass
 
 import torch
 

--- a/mala/datahandling/lazy_load_dataset_clustered.py
+++ b/mala/datahandling/lazy_load_dataset_clustered.py
@@ -7,11 +7,6 @@ except ModuleNotFoundError:
     # Warning is thrown by Parameters class.
     pass
 
-try:
-    import pqkmeans
-except ModuleNotFoundError:
-    pass
-
 import numpy as np
 import torch
 from torch.utils.data import Dataset
@@ -134,6 +129,10 @@ class LazyLoadDatasetClustered(torch.utils.data.Dataset):
                               self.sample_ratio)
 
     def __cluster_snapshot(self, snapshot_idx):
+        # Since pgkmeans is taking a while to load and is only rarely
+        # needed, I'll make this import per-demand.
+        import pqkmeans
+
 
         # Load the data into memory, and transform it as necessary.
         # I know, the here-and-there transform via torch is ugly, but

--- a/mala/descriptors/snap.py
+++ b/mala/descriptors/snap.py
@@ -15,11 +15,6 @@ try:
 except ModuleNotFoundError:
     pass
 
-try:
-    from mpi4py import MPI
-except ModuleNotFoundError:
-    pass
-
 from mala.descriptors.lammps_utils import *
 from mala.descriptors.descriptor import Descriptor
 from mala.common.parallelizer import get_comm, printout, get_rank, get_size, \

--- a/mala/interfaces/ase_calculator.py
+++ b/mala/interfaces/ase_calculator.py
@@ -2,11 +2,6 @@
 
 from ase.calculators.calculator import Calculator, all_changes
 import numpy as np
-try:
-    from mpi4py import MPI
-except:
-    # Warning thrown in parameters.py
-    pass
 from mala import Parameters, Network, DataHandler, Predictor, LDOS, Density, \
                  DOS
 from mala.common.parallelizer import get_rank, get_comm, barrier
@@ -134,6 +129,10 @@ class MALA(Calculator):
                                                               create_file=False)
         barrier()
         if self.params.use_mpi:
+            # I think we should refrain from top-level MPI imports; the first
+            # import triggers an MPI init, which can take quite long.
+            from mpi4py import MPI
+
             energy = get_comm().bcast(energy, root=0)
             if "forces" in properties:
                 get_comm().Bcast([forces, MPI.DOUBLE], root=0)

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -4,10 +4,6 @@ from ase.units import Rydberg
 import numpy as np
 import math
 import os
-try:
-    from mpi4py import MPI
-except ModuleNotFoundError:
-    pass
 
 from mala.common.parallelizer import get_comm, printout, get_rank, get_size, \
     barrier
@@ -813,6 +809,10 @@ class LDOS(Target):
                              voxel_Bohr.volume
 
         if self.parameters._configuration["mpi"] and gather_dos:
+            # I think we should refrain from top-level MPI imports; the first
+            # import triggers an MPI init, which can take quite long.
+            from mpi4py import MPI
+
             comm = get_comm()
             comm.Barrier()
             dos_values_full = np.zeros_like(dos_values)

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -9,10 +9,6 @@ import ase.io
 import numpy as np
 from scipy.spatial import distance
 from scipy.integrate import simps
-try:
-    from asap3.analysis.rdf import RadialDistributionFunction
-except ModuleNotFoundError:
-    pass
 
 from mala.common.parameters import Parameters, ParametersTargets
 from mala.common.parallelizer import printout
@@ -466,6 +462,9 @@ class Target(ABC):
                 rr.append((i - 0.5) * dr)
                 rdf[i] /= (norm * ((rr[-1] ** 2) + (dr ** 2) / 12.))
         elif method == "asap3":
+            # ASAP3 loads MPI which takes a long time to import, so
+            # we'll only do that when absolutely needed.
+            from asap3.analysis.rdf import RadialDistributionFunction
             rdf = RadialDistributionFunction(atoms, rMax,
                                              number_of_bins).get_rdf()
             rr = []


### PR DESCRIPTION
Made mpi4py and pqkmeans loading per-demand, reduces loading time by 90%. The main time left is done by torch and optuna, but I don't really see a way around that. 

Closes #314 .