### PR TITLE
Fixed naming for fermi energy and temperature variables

### DIFF
--- a/examples/ex12_run_predictions.py
+++ b/examples/ex12_run_predictions.py
@@ -53,14 +53,14 @@ def use_predictor(new_network, new_parameters, iscaler, oscaler):
     # and for that we also have to tell the calculator how many electrons
     # the system has and at which temperature we perform calculations.
     ldos_calculator.number_of_electrons_exact = 4
-    ldos_calculator.temperature_K = 298
+    ldos_calculator.temperature = 298
 
-    fermi_energy = ldos_calculator.get_self_consistent_fermi_energy_ev(ldos)
+    fermi_energy = ldos_calculator.get_self_consistent_fermi_energy(ldos)
 
-    number_of_electrons = ldos_calculator.\
-        get_number_of_electrons(ldos, fermi_energy_eV=fermi_energy)
+    number_of_electrons = ldos_calculator. \
+        get_number_of_electrons(ldos, fermi_energy=fermi_energy)
     band_energy = ldos_calculator. \
-        get_band_energy(ldos, fermi_energy_eV=fermi_energy)
+        get_band_energy(ldos, fermi_energy=fermi_energy)
     printout("Predicted number of electrons: ", number_of_electrons)
     printout("Predicted band energy: ", band_energy)
 

--- a/mala/interfaces/ase_calculator.py
+++ b/mala/interfaces/ase_calculator.py
@@ -116,15 +116,14 @@ class MALA(Calculator):
 
             # Get DOS and density.
             dos = ldos_calculator.get_density_of_states(ldos, gather_dos=False)
-            fermi_energy_ev = dos_calculator.get_self_consistent_fermi_energy_ev(
-                dos)
+            fermi_energy = dos_calculator.get_self_consistent_fermi_energy(dos)
             density = ldos_calculator.get_density(ldos,
-                                                  fermi_energy_eV=fermi_energy_ev)
-            energy, self.last_energy_contributions = ldos_calculator.\
-            get_total_energy(dos_data=dos, density_data=density,
-                             fermi_energy_eV=fermi_energy_ev,
-                             create_qe_file=False,
-                             return_energy_contributions=True)
+                                                  fermi_energy=fermi_energy)
+            energy, self.last_energy_contributions = ldos_calculator. \
+                get_total_energy(dos_data=dos, density_data=density,
+                                 fermi_energy=fermi_energy,
+                                 create_qe_file=False,
+                                 return_energy_contributions=True)
             if "forces" in properties:
                 forces = density_calculator.get_atomic_forces(density,
                                                               create_file=False)

--- a/mala/network/trainer.py
+++ b/mala/network/trainer.py
@@ -590,16 +590,16 @@ class Trainer(Runner):
                     read_additional_calculation_data("qe.out",
                                                      self.data.get_snapshot_calculation_output(snapshot_number))
                 fe_actual = calculator.\
-                    get_self_consistent_fermi_energy_ev(actual_outputs)
+                    get_self_consistent_fermi_energy(actual_outputs)
                 be_actual = calculator.\
-                    get_band_energy(actual_outputs, fermi_energy_eV=fe_actual)
+                    get_band_energy(actual_outputs, fermi_energy=fe_actual)
 
                 try:
                     fe_predicted = calculator.\
-                        get_self_consistent_fermi_energy_ev(predicted_outputs)
+                        get_self_consistent_fermi_energy(predicted_outputs)
                     be_predicted = calculator.\
                         get_band_energy(predicted_outputs,
-                                        fermi_energy_eV=fe_predicted)
+                                        fermi_energy=fe_predicted)
                 except ValueError:
                     # If the training went badly, it might be that the above
                     # code results in an error, due to the LDOS being so wrong
@@ -633,17 +633,17 @@ class Trainer(Runner):
                     read_additional_calculation_data("qe.out",
                                                      self.data.get_snapshot_calculation_output(snapshot_number))
                 fe_actual = calculator.\
-                    get_self_consistent_fermi_energy_ev(actual_outputs)
+                    get_self_consistent_fermi_energy(actual_outputs)
                 te_actual = calculator.\
                     get_total_energy(ldos_data=actual_outputs,
-                                     fermi_energy_eV=fe_actual)
+                                     fermi_energy=fe_actual)
 
                 try:
                     fe_predicted = calculator.\
-                        get_self_consistent_fermi_energy_ev(predicted_outputs)
+                        get_self_consistent_fermi_energy(predicted_outputs)
                     te_predicted = calculator.\
                         get_total_energy(ldos_data=actual_outputs,
-                                         fermi_energy_eV=fe_predicted)
+                                         fermi_energy=fe_predicted)
                 except ValueError:
                     # If the training went badly, it might be that the above
                     # code results in an error, due to the LDOS being so wrong

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -131,7 +131,7 @@ class Density(Target):
         """
         return_density_object = Density(ldos_object.parameters)
         return_density_object.fermi_energy_dft = ldos_object.fermi_energy_dft
-        return_density_object.temperature_K = ldos_object.temperature_K
+        return_density_object.temperature = ldos_object.temperature
         return_density_object.voxel = ldos_object.voxel
         return_density_object.number_of_electrons_exact = ldos_object.\
             number_of_electrons_exact

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -52,7 +52,7 @@ class DOS(Target):
         """
         return_dos_object = DOS(ldos_object.parameters)
         return_dos_object.fermi_energy_dft = ldos_object.fermi_energy_dft
-        return_dos_object.temperature_K = ldos_object.temperature_K
+        return_dos_object.temperature = ldos_object.temperature
         return_dos_object.voxel = ldos_object.voxel
         return_dos_object.number_of_electrons_exact = \
             ldos_object.number_of_electrons_exact
@@ -264,8 +264,8 @@ class DOS(Target):
         from how this quantity is calculated. Calculated via cached DOS.
         """
         if self.density_of_states is not None:
-            fermi_energy = self.\
-                get_self_consistent_fermi_energy_ev()
+            fermi_energy = self. \
+                get_self_consistent_fermi_energy()
 
             # Now that we have a new Fermi energy, we should uncache the
             # old number of electrons.
@@ -501,8 +501,8 @@ class DOS(Target):
         linspace_array = (np.linspace(emin, emax, grid_size, endpoint=False))
         return linspace_array
 
-    def get_band_energy(self, dos_data=None, fermi_energy_eV=None,
-                        temperature_K=None, integration_method="analytical",
+    def get_band_energy(self, dos_data=None, fermi_energy=None,
+                        temperature=None, integration_method="analytical",
                         broadcast_band_energy=True):
         """
         Calculate the band energy from given DOS data.
@@ -513,10 +513,10 @@ class DOS(Target):
             DOS data with dimension [energygrid]. If None, then the cached
             DOS will be used for the calculation.
 
-        fermi_energy_eV : float
+        fermi_energy : float
             Fermi energy level in eV.
 
-        temperature_K : float
+        temperature : float
             Temperature in K.
 
         integration_method : string
@@ -544,25 +544,25 @@ class DOS(Target):
         # Here we check whether we will use our internal, cached
         # DOS, or calculate everything from scratch.
         if dos_data is not None:
-            if fermi_energy_eV is None:
+            if fermi_energy is None:
                 printout("Warning: No fermi energy was provided or could be "
                          "calculated from electronic structure data. "
                          "Using the DFT fermi energy, this may "
                          "yield unexpected results", min_verbosity=1)
-                fermi_energy_eV = self.fermi_energy_dft
+                fermi_energy = self.fermi_energy_dft
         else:
             dos_data = self.density_of_states
-            fermi_energy_eV = self.fermi_energy
-        if temperature_K is None:
-            temperature_K = self.temperature_K
+            fermi_energy = self.fermi_energy
+        if temperature is None:
+            temperature = self.temperature
 
         if self.parameters._configuration["mpi"] and broadcast_band_energy:
             if get_rank() == 0:
                 energy_grid = self.energy_grid
                 band_energy = self.__band_energy_from_dos(dos_data,
                                                           energy_grid,
-                                                          fermi_energy_eV,
-                                                          temperature_K,
+                                                          fermi_energy,
+                                                          temperature,
                                                           integration_method)
             else:
                 band_energy = None
@@ -573,16 +573,15 @@ class DOS(Target):
         else:
             energy_grid = self.energy_grid
             return self.__band_energy_from_dos(dos_data, energy_grid,
-                                               fermi_energy_eV, temperature_K,
+                                               fermi_energy, temperature,
                                                integration_method)
 
 
-        return self.__band_energy_from_dos(dos_data, energy_grid,
-                                           fermi_energy_eV, temperature_K,
-                                           integration_method)
+        return self.__band_energy_from_dos(dos_data, energy_grid, fermi_energy,
+                                           temperature, integration_method)
 
-    def get_number_of_electrons(self, dos_data=None, fermi_energy_eV=None,
-                                temperature_K=None,
+    def get_number_of_electrons(self, dos_data=None, fermi_energy=None,
+                                temperature=None,
                                 integration_method="analytical"):
         """
         Calculate the number of electrons from given DOS data.
@@ -593,10 +592,10 @@ class DOS(Target):
             DOS data with dimension [energygrid]. If None, then the cached
             DOS will be used for the calculation.
 
-        fermi_energy_eV : float
+        fermi_energy : float
             Fermi energy level in eV.
 
-        temperature_K : float
+        temperature : float
             Temperature in K.
 
         integration_method : string
@@ -619,26 +618,25 @@ class DOS(Target):
         # Here we check whether we will use our internal, cached
         # DOS, or calculate everything from scratch.
         if dos_data is not None:
-            if fermi_energy_eV is None:
+            if fermi_energy is None:
                 printout("Warning: No fermi energy was provided or could be "
                          "calculated from electronic structure data. "
                          "Using the DFT fermi energy, this may "
                          "yield unexpected results", min_verbosity=1)
-                fermi_energy_eV = self.fermi_energy_dft
+                fermi_energy = self.fermi_energy_dft
         else:
             dos_data = self.density_of_states
-            fermi_energy_eV = self.fermi_energy
+            fermi_energy = self.fermi_energy
 
-        if temperature_K is None:
-            temperature_K = self.temperature_K
+        if temperature is None:
+            temperature = self.temperature
         energy_grid = self.energy_grid
         return self.__number_of_electrons_from_dos(dos_data, energy_grid,
-                                                   fermi_energy_eV,
-                                                   temperature_K,
+                                                   fermi_energy, temperature,
                                                    integration_method)
 
-    def get_entropy_contribution(self, dos_data=None, fermi_energy_eV=None,
-                                 temperature_K=None,
+    def get_entropy_contribution(self, dos_data=None, fermi_energy=None,
+                                 temperature=None,
                                  integration_method="analytical",
                                  broadcast_entropy=True):
         """
@@ -650,10 +648,10 @@ class DOS(Target):
             DOS data with dimension [energygrid]. If None, then the cached
             DOS will be used for the calculation.
 
-        fermi_energy_eV : float
+        fermi_energy : float
             Fermi energy level in eV.
 
-        temperature_K : float
+        temperature : float
             Temperature in K.
 
         integration_method : string
@@ -680,25 +678,24 @@ class DOS(Target):
         # Here we check whether we will use our internal, cached
         # DOS, or calculate everything from scratch.
         if dos_data is not None:
-            if fermi_energy_eV is None:
+            if fermi_energy is None:
                 printout("Warning: No fermi energy was provided or could be "
                          "calculated from electronic structure data. "
                          "Using the DFT fermi energy, this may "
                          "yield unexpected results", min_verbosity=1)
-                fermi_energy_eV = self.fermi_energy_dft
+                fermi_energy = self.fermi_energy_dft
         else:
             dos_data = self.density_of_states
-            fermi_energy_eV = self.fermi_energy
-        if temperature_K is None:
-            temperature_K = self.temperature_K
+            fermi_energy = self.fermi_energy
+        if temperature is None:
+            temperature = self.temperature
 
         if self.parameters._configuration["mpi"] and broadcast_entropy:
             if get_rank() == 0:
                 energy_grid = self.energy_grid
                 entropy = self. \
                     __entropy_contribution_from_dos(dos_data, energy_grid,
-                                                    fermi_energy_eV,
-                                                    temperature_K,
+                                                    fermi_energy, temperature,
                                                     integration_method)
             else:
                 entropy = None
@@ -708,15 +705,14 @@ class DOS(Target):
             return entropy
         else:
             energy_grid = self.energy_grid
-            return self.\
+            return self. \
                 __entropy_contribution_from_dos(dos_data, energy_grid,
-                                                fermi_energy_eV, temperature_K,
+                                                fermi_energy, temperature,
                                                 integration_method)
 
-    def get_self_consistent_fermi_energy_ev(self, dos_data=None,
-                                            temperature_K=None,
-                                            integration_method="analytical",
-                                            broadcast_fermi_energy=True):
+    def get_self_consistent_fermi_energy(self, dos_data=None, temperature=None,
+                                         integration_method="analytical",
+                                         broadcast_fermi_energy=True):
         r"""
         Calculate the self-consistent Fermi energy.
 
@@ -731,7 +727,7 @@ class DOS(Target):
             DOS data with dimension [energygrid]. If None, then the cached
             DOS will be used for the calculation.
 
-        temperature_K : float
+        temperature : float
             Temperature in K.
 
         integration_method : string
@@ -756,8 +752,8 @@ class DOS(Target):
                 raise Exception("No DOS data provided, cannot calculate"
                                 " this quantity.")
 
-        if temperature_K is None:
-            temperature_K = self.temperature_K
+        if temperature is None:
+            temperature = self.temperature
 
         if self.parameters._configuration["mpi"] and broadcast_fermi_energy:
             if get_rank() == 0:
@@ -766,7 +762,7 @@ class DOS(Target):
                                           (self.
                                            __number_of_electrons_from_dos
                                            (dos_data, energy_grid,
-                                            fermi_sc, temperature_K,
+                                            fermi_sc, temperature,
                                             integration_method)
                                            - self.number_of_electrons_exact),
                                           a=energy_grid[0],
@@ -783,7 +779,7 @@ class DOS(Target):
                                       (self.
                                        __number_of_electrons_from_dos
                                        (dos_data, energy_grid,
-                                        fermi_sc, temperature_K,
+                                        fermi_sc, temperature,
                                         integration_method)
                                        - self.number_of_electrons_exact),
                                       a=energy_grid[0],
@@ -808,13 +804,12 @@ class DOS(Target):
     #################
 
     @staticmethod
-    def __number_of_electrons_from_dos(dos_data, energy_grid, fermi_energy_eV,
-                                       temperature_K, integration_method):
+    def __number_of_electrons_from_dos(dos_data, energy_grid, fermi_energy,
+                                       temperature, integration_method):
         """Calculate the number of electrons from DOS data."""
         # Calculate the energy levels and the Fermi function.
 
-        fermi_vals = fermi_function(energy_grid, fermi_energy_eV,
-                                    temperature_K)
+        fermi_vals = fermi_function(energy_grid, fermi_energy, temperature)
         # Calculate the number of electrons.
         if integration_method == "trapz":
             number_of_electrons = integrate.trapz(dos_data * fermi_vals,
@@ -825,28 +820,26 @@ class DOS(Target):
         elif integration_method == "quad":
             dos_pointer = interpolate.interp1d(energy_grid, dos_data)
             number_of_electrons, abserr = integrate.quad(
-                lambda e: dos_pointer(e) * fermi_function(e, fermi_energy_eV,
-                                                          temperature_K),
+                lambda e: dos_pointer(e) * fermi_function(e, fermi_energy,
+                                                          temperature),
                 energy_grid[0], energy_grid[-1], limit=500,
-                points=fermi_energy_eV)
+                points=fermi_energy)
         elif integration_method == "analytical":
             number_of_electrons = analytical_integration(dos_data, "F0", "F1",
-                                                         fermi_energy_eV,
+                                                         fermi_energy,
                                                          energy_grid,
-                                                         temperature_K)
+                                                         temperature)
         else:
             raise Exception("Unknown integration method.")
 
         return number_of_electrons
 
     @staticmethod
-    def __band_energy_from_dos(dos_data, energy_grid,
-                               fermi_energy_eV,
-                               temperature_K, integration_method):
+    def __band_energy_from_dos(dos_data, energy_grid, fermi_energy,
+                               temperature, integration_method):
         """Calculate the band energy from DOS data."""
         # Calculate the energy levels and the Fermi function.
-        fermi_vals = fermi_function(energy_grid, fermi_energy_eV,
-                                    temperature_K)
+        fermi_vals = fermi_function(energy_grid, fermi_energy, temperature)
 
         # Calculate the band energy.
         if integration_method == "trapz":
@@ -860,30 +853,29 @@ class DOS(Target):
         elif integration_method == "quad":
             dos_pointer = interpolate.interp1d(energy_grid, dos_data)
             band_energy, abserr = integrate.quad(
-                lambda e: dos_pointer(e) * e * fermi_function(e,
-                                                              fermi_energy_eV,
-                                                              temperature_K),
+                lambda e: dos_pointer(e) * e * fermi_function(e, fermi_energy,
+                                                              temperature),
                 energy_grid[0], energy_grid[-1], limit=500,
-                points=fermi_energy_eV)
+                points=fermi_energy)
         elif integration_method == "analytical":
             number_of_electrons = analytical_integration(dos_data, "F0", "F1",
-                                                         fermi_energy_eV,
+                                                         fermi_energy,
                                                          energy_grid,
-                                                         temperature_K)
+                                                         temperature)
             band_energy_minus_uN = analytical_integration(dos_data, "F1", "F2",
-                                                          fermi_energy_eV,
+                                                          fermi_energy,
                                                           energy_grid,
-                                                          temperature_K)
-            band_energy = band_energy_minus_uN+fermi_energy_eV *\
-                number_of_electrons
+                                                          temperature)
+            band_energy = band_energy_minus_uN + fermi_energy * \
+                          number_of_electrons
         else:
             raise Exception("Unknown integration method.")
 
         return band_energy
 
     @staticmethod
-    def __entropy_contribution_from_dos(dos_data, energy_grid, fermi_energy_eV,
-                                        temperature_K, integration_method):
+    def __entropy_contribution_from_dos(dos_data, energy_grid, fermi_energy,
+                                        temperature, integration_method):
         r"""
         Calculate the entropy contribution to the total energy from DOS data.
 
@@ -891,31 +883,31 @@ class DOS(Target):
         """
         # Calculate the entropy contribution to the energy.
         if integration_method == "trapz":
-            multiplicator = entropy_multiplicator(energy_grid,
-                                                  fermi_energy_eV,
-                                                  temperature_K)
+            multiplicator = entropy_multiplicator(energy_grid, fermi_energy,
+                                                  temperature)
             entropy_contribution = integrate.trapz(dos_data * multiplicator,
                                                    energy_grid, axis=-1)
-            entropy_contribution /= get_beta(temperature_K)
+            entropy_contribution /= get_beta(temperature)
         elif integration_method == "simps":
-            multiplicator = entropy_multiplicator(energy_grid, fermi_energy_eV,
-                                                  temperature_K)
+            multiplicator = entropy_multiplicator(energy_grid, fermi_energy,
+                                                  temperature)
             entropy_contribution = integrate.simps(dos_data * multiplicator,
                                                    energy_grid, axis=-1)
-            entropy_contribution /= get_beta(temperature_K)
+            entropy_contribution /= get_beta(temperature)
         elif integration_method == "quad":
             dos_pointer = interpolate.interp1d(energy_grid, dos_data)
             entropy_contribution, abserr = integrate.quad(
                 lambda e: dos_pointer(e) *
-                entropy_multiplicator(e, fermi_energy_eV, temperature_K),
+                          entropy_multiplicator(e, fermi_energy,
+                                                temperature),
                 energy_grid[0], energy_grid[-1], limit=500,
-                points=fermi_energy_eV)
-            entropy_contribution /= get_beta(temperature_K)
+                points=fermi_energy)
+            entropy_contribution /= get_beta(temperature)
         elif integration_method == "analytical":
             entropy_contribution = analytical_integration(dos_data, "S0", "S1",
-                                                          fermi_energy_eV,
+                                                          fermi_energy,
                                                           energy_grid,
-                                                          temperature_K)
+                                                          temperature)
         else:
             raise Exception("Unknown integration method.")
 

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -88,7 +88,7 @@ class Target(ABC):
         else:
             raise Exception("Wrong type of parameters for Targets class.")
         self.fermi_energy_dft = None
-        self.temperature_K = None
+        self.temperature = None
         self.voxel = None
         self.number_of_electrons_exact = None
         self.number_of_electrons_from_eigenvals = None
@@ -198,7 +198,7 @@ class Target(ABC):
         if data_type == "qe.out":
             # Reset everything.
             self.fermi_energy_dft = None
-            self.temperature_K = None
+            self.temperature = None
             self.number_of_electrons_exact = None
             self.voxel = None
             self.band_energy_dft_calculation = None
@@ -226,8 +226,8 @@ class Target(ABC):
                         self.number_of_electrons_exact = \
                             np.float64(line.split('=')[1])
                     if "Fermi-Dirac smearing, width (Ry)=" in line:
-                        self.temperature_K = np.float64(line.split('=')[2]) * \
-                                             Rydberg / kB
+                        self.temperature = np.float64(line.split('=')[2]) * \
+                                           Rydberg / kB
                     if "xc contribution" in line:
                         break
                     if "FFT dimensions" in line:
@@ -290,12 +290,11 @@ class Target(ABC):
                 kweights = self.atoms.get_calculator().get_k_point_weights()
                 eband_per_band = eigs * fermi_function(eigs,
                                                        self.fermi_energy_dft,
-                                                       self.temperature_K)
+                                                       self.temperature)
                 eband_per_band = kweights[np.newaxis, :] * eband_per_band
                 self.band_energy_dft_calculation = np.sum(eband_per_band)
-                enum_per_band = fermi_function(eigs,
-                                               self.fermi_energy_dft,
-                                               self.temperature_K)
+                enum_per_band = fermi_function(eigs, self.fermi_energy_dft,
+                                               self.temperature)
                 enum_per_band = kweights[np.newaxis, :] * enum_per_band
                 self.number_of_electrons_from_eigenvals = np.sum(enum_per_band)
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -74,13 +74,13 @@ class TestMALAIntegration:
 
         # Calculate the numerically approximated values.
         qint_0, abserr = sp.integrate.quad(
-            lambda e: fermi_function_eV(e, e_fermi, temp),
+            lambda e: fermi_function(e, e_fermi, temp),
             energies[0], energies[-1])
         qint_1, abserr = sp.integrate.quad(
-            lambda e: (e - e_fermi) * fermi_function_eV(e, e_fermi, temp),
+            lambda e: (e - e_fermi) * fermi_function(e, e_fermi, temp),
             energies[0], energies[-1])
         qint_2, abserr = sp.integrate.quad(
-            lambda e: (e - e_fermi) ** 2 * fermi_function_eV(e, e_fermi, temp),
+            lambda e: (e - e_fermi) ** 2 * fermi_function(e, e_fermi, temp),
             energies[0], energies[-1])
 
         # Calculate the errors.
@@ -141,10 +141,10 @@ class TestMALAIntegration:
                                                  "1/(eV*Bohr^3)")
 
         # Calculate the quantities we want to compare.
-        self_consistent_fermi_energy = ldos_calculator.\
-            get_self_consistent_fermi_energy_ev(ldos_dft)
+        self_consistent_fermi_energy = ldos_calculator. \
+            get_self_consistent_fermi_energy(ldos_dft)
         density_mala = ldos_calculator. \
-            get_density(ldos_dft, fermi_energy_eV=self_consistent_fermi_energy)
+            get_density(ldos_dft, fermi_energy=self_consistent_fermi_energy)
         density_mala_sum = density_mala.sum()
         density_dft_sum = density_dft.sum()
 

--- a/test/workflow_test.py
+++ b/test/workflow_test.py
@@ -94,12 +94,12 @@ class TestFullWorkflow:
 
         # Calculate energies
         self_consistent_fermi_energy = dos. \
-            get_self_consistent_fermi_energy_ev(dos_data)
+            get_self_consistent_fermi_energy(dos_data)
         number_of_electrons = dos. \
-            get_number_of_electrons(dos_data, fermi_energy_eV=
+            get_number_of_electrons(dos_data, fermi_energy=
                                     self_consistent_fermi_energy)
         band_energy = dos.get_band_energy(dos_data,
-                                          fermi_energy_eV=
+                                          fermi_energy=
                                           self_consistent_fermi_energy)
 
         assert np.isclose(number_of_electrons, dos.number_of_electrons_exact,
@@ -132,12 +132,12 @@ class TestFullWorkflow:
 
         # Calculate energies
         self_consistent_fermi_energy = ldos. \
-            get_self_consistent_fermi_energy_ev(ldos_data)
+            get_self_consistent_fermi_energy(ldos_data)
         number_of_electrons = ldos. \
-            get_number_of_electrons(ldos_data, fermi_energy_eV=
+            get_number_of_electrons(ldos_data, fermi_energy=
                                     self_consistent_fermi_energy)
         band_energy = ldos.get_band_energy(ldos_data,
-                                           fermi_energy_eV=
+                                           fermi_energy=
                                            self_consistent_fermi_energy)
 
         assert np.isclose(number_of_electrons, ldos.number_of_electrons_exact,
@@ -173,11 +173,11 @@ class TestFullWorkflow:
 
         # Calculate energies
         self_consistent_fermi_energy = dos. \
-            get_self_consistent_fermi_energy_ev(dos_data)
+            get_self_consistent_fermi_energy(dos_data)
 
         total_energy = ldos.get_total_energy(dos_data=dos_data,
                                              density_data=dens_data,
-                                             fermi_energy_eV=
+                                             fermi_energy=
                                              self_consistent_fermi_energy)
         assert np.isclose(total_energy, ldos.total_energy_dft_calculation,
                           atol=accuracy_total_energy)
@@ -209,9 +209,9 @@ class TestFullWorkflow:
 
         # Calculate energies
         self_consistent_fermi_energy = ldos. \
-            get_self_consistent_fermi_energy_ev(ldos_data)
+            get_self_consistent_fermi_energy(ldos_data)
         total_energy = ldos.get_total_energy(ldos_data,
-                                             fermi_energy_eV=
+                                             fermi_energy=
                                              self_consistent_fermi_energy)
         assert np.isclose(total_energy, ldos.total_energy_dft_calculation,
                           atol=accuracy_total_energy)


### PR DESCRIPTION
Removed "_ev", "_eV", "_k" and "_K". MALA has standard units (all energies in eV, all temperatutes in K), so this is not needed for now. 