### PR TITLE
Update density.py to use uneven z splitting

### DIFF
--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -797,6 +797,9 @@ class Density(Target):
 
             density_for_qe = np.reshape(density_for_qe, [number_of_gridpoints,
                                                          1], order='F')
+            if density_for_qe.shape[0] < number_of_gridpoints:
+                grid_diff = number_of_gridpoints - number_of_gridpoints_mala
+                density_for_qe = np.pad(density_for_qe, pad_width=((0, grid_diff),(0,0)))
 
         # QE has the density in 1/Bohr^3
         density_for_qe *= self.backconvert_units(1, "1/Bohr^3")


### PR DESCRIPTION
When uneven zsplitting occurs each rank contains a nonuniform number of grid points. Quantum Espresso expects one value of gridpoints on all ranks. The padding of the density on lower grid point ranks allows Quantum Espresso to accept the density arrays as input for total energy calculations.