### PR TITLE
Fix mirror workflow

### DIFF
--- a/.github/workflows/mirror-to-casus.yml
+++ b/.github/workflows/mirror-to-casus.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: mirror-repository
       uses: spyoungtech/mirror-action@v0.4.0
       with:

--- a/.github/workflows/mirror-to-casus.yml
+++ b/.github/workflows/mirror-to-casus.yml
@@ -10,7 +10,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: mirror-repository
-      uses: spyoungtech/mirror-action@v0.4.0
+      uses: spyoungtech/mirror-action@v0.6.0
       with:
         REMOTE: git@github.com:casus/mala.git
         GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_KEY }}

--- a/.github/workflows/mirror-to-casus.yml
+++ b/.github/workflows/mirror-to-casus.yml
@@ -12,7 +12,7 @@ jobs:
     - name: mirror-repository
       uses: spyoungtech/mirror-action@v0.6.0
       with:
-        REMOTE: git@github.com:casus/mala.git
+        REMOTE: 'ssh://git@github.com/casus/mala.git'
         GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_KEY }}
         GIT_SSH_NO_VERIFY_HOST: "true"
         DEBUG: "true"


### PR DESCRIPTION
This PR fixes the mirror workflow. This was broken for months. 

With this PR I also wanted to enable host verification:

> To obtain the public key for the `GIT_SSH_KNOWN_HOSTS` secret, we have
    issued the command `ssh-keyscan -t rsa github.com`.

However, this fails and will probably be fixed once [this PR](https://github.com/yesolutions/mirror-action/pull/19) of the mirror action used is merged.