### PR TITLE
Added overflow check in Fermi function

### DIFF
--- a/mala/targets/calculation_helpers.py
+++ b/mala/targets/calculation_helpers.py
@@ -3,7 +3,7 @@ from ase.units import kB
 import mpmath as mp
 import numpy as np
 from scipy import integrate
-
+import sys
 
 def integrate_values_on_spacing(values, spacing, method, axis=0):
     """
@@ -72,9 +72,13 @@ def fermi_function(energy, fermi_energy, temperature):
     # therefore get zero (or machine precision within zero) either way.
     # Adding this check removes overflow warnings.
     # The overhead for inference should be minimal.
-    max_exponent = np.finfo(exponent.dtype.name).max
-    overflow = np.argwhere(exponent > max_exponent)
-    exponent[overflow] = max_exponent
+    # Since this function works both for arrays and scalars,
+    # we have to check which maximum to use.
+    if type(energy) == np.ndarray:
+        max_exponent = np.log(np.finfo(exponent.dtype.name).max)
+        exponent[np.argwhere(exponent > max_exponent)] = max_exponent
+    else:
+        exponent = min(exponent, np.log(sys.float_info.max))
 
     return 1.0 / (1.0 + np.exp(exponent))
 

--- a/mala/targets/calculation_helpers.py
+++ b/mala/targets/calculation_helpers.py
@@ -74,11 +74,11 @@ def fermi_function(energy, fermi_energy, temperature):
     # The overhead for inference should be minimal.
     # Since this function works both for arrays and scalars,
     # we have to check which maximum to use.
-    if type(energy) == np.ndarray:
-        max_exponent = np.log(np.finfo(exponent.dtype.name).max)
-        exponent[np.argwhere(exponent > max_exponent)] = max_exponent
+    if isinstance(energy, np.ndarray):
+        max_exponent = np.log(np.finfo(exponent.dtype).max)
+        exponent[exponent > max_exponent] = max_exponent
     else:
-        exponent = min(exponent, np.log(sys.float_info.max))
+        exponent = min(exponent, np.log(np.finfo(exponent).max))
 
     return 1.0 / (1.0 + np.exp(exponent))
 

--- a/mala/targets/calculation_helpers.py
+++ b/mala/targets/calculation_helpers.py
@@ -38,7 +38,8 @@ def integrate_values_on_spacing(values, spacing, method, axis=0):
         raise Exception("Unknown integration method.")
 
 
-def fermi_function(energy, fermi_energy, temperature):
+def fermi_function(energy, fermi_energy, temperature,
+                   suppress_overflow=False):
     r"""
     Calculate the Fermi function.
 
@@ -51,10 +52,17 @@ def fermi_function(energy, fermi_energy, temperature):
     energy : float or numpy.array
         Energy for which the Fermi function is supposed to be calculated in
         energy_units.
+
     fermi_energy : float
         Fermi energy level in energy_units.
+
     temperature : float
         Temperature in K.
+
+    suppress_overflow : bool
+        If True, overflow that may occur in the exponent of the divisor of
+        the Fermi function is suppressed. This is mathematically justifiable,
+        but
 
     Returns
     -------
@@ -64,21 +72,23 @@ def fermi_function(energy, fermi_energy, temperature):
     """
     exponent = (energy - fermi_energy) / (kB * temperature)
 
-    # Maximum exponent that will not result in inf when performing
-    # np.exp() (for double values only).
-    # Very large exponents result in very large values, and if we don't check
-    # for overflow, infinity. Cutting this back to the maximum float value
-    # (~ 1e308) is more then enough, since we divide by the exponent, and
-    # therefore get zero (or machine precision within zero) either way.
-    # Adding this check removes overflow warnings.
-    # The overhead for inference should be minimal.
-    # Since this function works both for arrays and scalars,
-    # we have to check which maximum to use.
-    if isinstance(energy, np.ndarray):
-        max_exponent = np.log(np.finfo(exponent.dtype).max)
-        exponent[exponent > max_exponent] = max_exponent
-    else:
-        exponent = min(exponent, np.log(np.finfo(exponent).max))
+    if suppress_overflow:
+        # Maximum exponent that will not result in inf when performing
+        # np.exp() (for double values only).
+        # Very large exponents result in very large values, and if we don't
+        # check for overflow, infinity. Cutting this back to the maximum float
+        # value (~ 1e308) is more then enough, since we divide by the exponent,
+        # and therefore get zero (or machine precision within zero) either way.
+        # Adding this check removes overflow warnings.
+        # The overhead for inference should be minimal.
+        # Since this function works both for arrays and scalars,
+        # we have to check which maximum to use.
+
+        if isinstance(energy, np.ndarray):
+            max_exponent = np.log(np.finfo(exponent.dtype).max)
+            exponent[exponent > max_exponent] = max_exponent
+        else:
+            exponent = min(exponent, np.log(np.finfo(exponent).max))
 
     return 1.0 / (1.0 + np.exp(exponent))
 
@@ -112,7 +122,8 @@ def entropy_multiplicator(energy, fermi_energy, temperature):
         dim = np.shape(energy)[0]
         multiplicator = np.zeros(dim, dtype=np.float64)
         for i in range(0, np.shape(energy)[0]):
-            fermi_val = fermi_function(energy[i], fermi_energy, temperature)
+            fermi_val = fermi_function(energy[i], fermi_energy, temperature,
+                                       suppress_overflow=True)
             if fermi_val == 1.0:
                 secondterm = 0.0
             else:
@@ -123,7 +134,8 @@ def entropy_multiplicator(energy, fermi_energy, temperature):
                 firsterm = fermi_val * np.log(fermi_val)
             multiplicator[i] = firsterm + secondterm
     else:
-        fermi_val = fermi_function(energy, fermi_energy, temperature)
+        fermi_val = fermi_function(energy, fermi_energy, temperature,
+                                   suppress_overflow=True)
         if fermi_val == 1.0:
             secondterm = 0.0
         else:

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -824,7 +824,8 @@ class DOS(Target):
         """Calculate the number of electrons from DOS data."""
         # Calculate the energy levels and the Fermi function.
 
-        fermi_vals = fermi_function(energy_grid, fermi_energy, temperature)
+        fermi_vals = fermi_function(energy_grid, fermi_energy, temperature,
+                                    suppress_overflow=True)
         # Calculate the number of electrons.
         if integration_method == "trapz":
             number_of_electrons = integrate.trapz(dos_data * fermi_vals,
@@ -836,7 +837,8 @@ class DOS(Target):
             dos_pointer = interpolate.interp1d(energy_grid, dos_data)
             number_of_electrons, abserr = integrate.quad(
                 lambda e: dos_pointer(e) * fermi_function(e, fermi_energy,
-                                                          temperature),
+                                                          temperature,
+                                                          suppress_overflow=True),
                 energy_grid[0], energy_grid[-1], limit=500,
                 points=fermi_energy)
         elif integration_method == "analytical":
@@ -854,7 +856,8 @@ class DOS(Target):
                                temperature, integration_method):
         """Calculate the band energy from DOS data."""
         # Calculate the energy levels and the Fermi function.
-        fermi_vals = fermi_function(energy_grid, fermi_energy, temperature)
+        fermi_vals = fermi_function(energy_grid, fermi_energy, temperature,
+                                    suppress_overflow=True)
 
         # Calculate the band energy.
         if integration_method == "trapz":
@@ -869,7 +872,8 @@ class DOS(Target):
             dos_pointer = interpolate.interp1d(energy_grid, dos_data)
             band_energy, abserr = integrate.quad(
                 lambda e: dos_pointer(e) * e * fermi_function(e, fermi_energy,
-                                                              temperature),
+                                                              temperature,
+                                                              suppress_overflow=True),
                 energy_grid[0], energy_grid[-1], limit=500,
                 points=fermi_energy)
         elif integration_method == "analytical":

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -1010,7 +1010,8 @@ class LDOS(Target):
 
         # Build the energy grid and calculate the fermi function.
         energy_grid = self.get_energy_grid()
-        fermi_values = fermi_function(energy_grid, fermi_energy, temperature)
+        fermi_values = fermi_function(energy_grid, fermi_energy, temperature,
+                                      suppress_overflow=True)
 
         # Calculate the number of electrons.
         if integration_method == "trapz":

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -352,11 +352,13 @@ class Target(PhysicalData):
                 kweights = self.atoms.get_calculator().get_k_point_weights()
                 eband_per_band = eigs * fermi_function(eigs,
                                                        self.fermi_energy_dft,
-                                                       self.temperature)
+                                                       self.temperature,
+                                                       suppress_overflow=True)
                 eband_per_band = kweights[np.newaxis, :] * eband_per_band
                 self.band_energy_dft_calculation = np.sum(eband_per_band)
                 enum_per_band = fermi_function(eigs, self.fermi_energy_dft,
-                                               self.temperature)
+                                               self.temperature,
+                                               suppress_overflow=True)
                 enum_per_band = kweights[np.newaxis, :] * enum_per_band
                 self.number_of_electrons_from_eigenvals = np.sum(enum_per_band)
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -74,13 +74,15 @@ class TestMALAIntegration:
 
         # Calculate the numerically approximated values.
         qint_0, abserr = sp.integrate.quad(
-            lambda e: fermi_function(e, e_fermi, temp),
+            lambda e: fermi_function(e, e_fermi, temp, suppress_overflow=True),
             energies[0], energies[-1])
         qint_1, abserr = sp.integrate.quad(
-            lambda e: (e - e_fermi) * fermi_function(e, e_fermi, temp),
+            lambda e: (e - e_fermi) * fermi_function(e, e_fermi, temp,
+                                                     suppress_overflow=True),
             energies[0], energies[-1])
         qint_2, abserr = sp.integrate.quad(
-            lambda e: (e - e_fermi) ** 2 * fermi_function(e, e_fermi, temp),
+            lambda e: (e - e_fermi) ** 2 * fermi_function(e, e_fermi, temp,
+                                                          suppress_overflow=True),
             energies[0], energies[-1])
 
         # Calculate the errors.


### PR DESCRIPTION
This adds a check to make sure that the calculation of exp(x) does not result in an overflow in the Fermi function. It gets rid of the Runtime warning encountered in #60 .