### PR TITLE
Made output formats consistent with ASE

### DIFF
--- a/examples/ex02_preprocess_data.py
+++ b/examples/ex02_preprocess_data.py
@@ -54,11 +54,11 @@ ldosfile = os.path.join(data_path, "cubes/tmp.pp*Be_ldos.cube")
 # The add_snapshot function can be called with a lot of options to reflect
 # the data to be processed.
 # The standard way is this: specifying descriptor, target and additional info.
-data_converter.add_snapshot(descriptor_input_type="qe.out",
+data_converter.add_snapshot(descriptor_input_type="espresso-out",
                             descriptor_input_path=outfile,
                             target_input_type=".cube",
                             target_input_path=ldosfile,
-                            additional_info_input_type="qe.out",
+                            additional_info_input_type="espresso-out",
                             additional_info_input_path=outfile,
                             target_units="1/(Ry*Bohr^3)")
 
@@ -80,7 +80,7 @@ data_converter.convert_snapshots(descriptor_save_path="./",
 # No matter which way you access the DataConvert, you can always specify
 # keywords (check API) for the calculators.
 data_converter = mala.DataConverter(test_parameters)
-data_converter.add_snapshot(descriptor_input_type="qe.out",
+data_converter.add_snapshot(descriptor_input_type="espresso-out",
                             descriptor_input_path=outfile,)
 data_converter.convert_snapshots(complete_save_path="./",
                                  naming_scheme="Be_snapshot_only_in*",

--- a/examples/ex03_postprocess_data.py
+++ b/examples/ex03_postprocess_data.py
@@ -54,8 +54,8 @@ ldos = mala.LDOS.from_numpy_file(test_parameters,
 # Read additional information about the calculation.
 # By doing this, the calculator is able to know e.g. the temperature
 # at which the calculation took place or the lattice constant used.
-ldos.read_additional_calculation_data("qe.out", os.path.join(
-                                      data_path, "Be.pw.scf.out"))
+ldos.read_additional_calculation_data(os.path.join(data_path,
+                                                   "Be.pw.scf.out"))
 
 # Get quantities of interest.
 # For better values in the post processing, it is recommended to

--- a/examples/ex05_training_with_postprocessing.py
+++ b/examples/ex05_training_with_postprocessing.py
@@ -64,9 +64,9 @@ def use_trained_network(network_path, params_path, input_scaler_path,
 
     # We will use the LDOS calculator to do some preprocessing.
     ldos_calculator = inference_data_handler.target_calculator
-    ldos_calculator.read_additional_calculation_data("qe.out", os.path.join(
-                                                     data_path,
-                                                     "Al.pw.scf.out"))
+    ldos_calculator.\
+        read_additional_calculation_data(os.path.join(data_path,
+                                                      "Al.pw.scf.out"))
 
     # Calculate the Band energy.
     band_energy_predicted = ldos_calculator.get_band_energy(predicted_ldos)

--- a/examples/ex15_ase_calculator.py
+++ b/examples/ex15_ase_calculator.py
@@ -43,7 +43,7 @@ def use_calculator(network, new_parameters, iscaler, oscaler):
     calculator = mala.MALA(new_parameters, network,
                            inference_data_handler,
                            reference_data=
-                                    ["qe.out",
+                                    ["espresso-out",
                                      os.path.join(data_path,
                                                   "Be_snapshot1.out")])
     atoms.set_calculator(calculator)

--- a/examples/ex17_visualize_electronic_structure.py
+++ b/examples/ex17_visualize_electronic_structure.py
@@ -30,7 +30,7 @@ density = np.reshape(density, [np.prod(grid_dimensions), 1])
 atoms = read(atoms_path)
 params = mala.Parameters()
 density_calculator = mala.Density(params)
-density_calculator.read_additional_calculation_data("atoms+grid", [atoms, grid_dimensions])
+density_calculator.read_additional_calculation_data([atoms, grid_dimensions])
 
 # The resulting cube file can be opened by e.g. VMD, VESTA or scenery.
 density_calculator.write_to_cube("Be_dens.cube", density, atoms, grid_dimensions)

--- a/mala/datahandling/data_converter.py
+++ b/mala/datahandling/data_converter.py
@@ -10,13 +10,13 @@ from mala.targets.target import Target
 from mala.version import __version__ as mala_version
 
 descriptor_input_types = [
-    "qe.out"
+    "espresso-out"
 ]
 target_input_types = [
     ".cube", ".xsf"
 ]
 additional_info_input_types = [
-    "qe.out"
+    "espresso-out"
 ]
 
 
@@ -441,7 +441,7 @@ class DataConverter:
         original_units = self.__snapshot_units[snapshot_number]
 
         # Parse and/or calculate the input descriptors.
-        if description["input"] == "qe.out":
+        if description["input"] == "espresso-out":
             descriptor_calculation_kwargs["units"] = original_units["input"]
             tmp_input, local_size = self.descriptor_calculator. \
                 calculate_from_qe_out(snapshot["input"],
@@ -506,8 +506,8 @@ class DataConverter:
                 else:
                     metadata = None
                     if description["metadata"] is not None:
-                        metadata = [description["metadata"],
-                                    snapshot["metadata"]]
+                        metadata = [snapshot["metadata"],
+                                    description["metadata"]]
 
                     self.target_calculator. \
                         write_to_openpmd_iteration(output_iteration,
@@ -516,18 +516,10 @@ class DataConverter:
                 del tmp_output
 
         # Parse and/or calculate the additional info.
-        if description["additional_info"] == "qe.out":
+        if description["additional_info"] is not None:
             # Parsing and saving is done using the target calculator.
             self.target_calculator. \
-                read_additional_calculation_data("qe.out",
-                                                 snapshot["additional_info"])
+                read_additional_calculation_data(snapshot["additional_info"],
+                                                 description["additional_info"])
             self.target_calculator. \
                 write_additional_calculation_data(additional_info_path)
-
-        elif description["additional_info"] is None:
-            # Not additional info provided, pass.
-            pass
-        else:
-            raise Exception(
-                "Unknown file extension, cannot convert additional info "
-                "data.")

--- a/mala/interfaces/ase_calculator.py
+++ b/mala/interfaces/ase_calculator.py
@@ -59,8 +59,8 @@ class MALA(Calculator):
 
         # Get critical values from a reference file (cutoff, temperature, etc.)
         self.data_handler.target_calculator.\
-            read_additional_calculation_data(reference_data[0],
-                                             reference_data[1])
+            read_additional_calculation_data(reference_data[1],
+                                             reference_data[0])
 
         # Needed for e.g. Monte Carlo.
         self.last_energy_contributions = {}

--- a/mala/network/predictor.py
+++ b/mala/network/predictor.py
@@ -62,7 +62,7 @@ class Predictor(Runner):
             Precicted LDOS for these atomic positions.
         """
         self.data.target_calculator.\
-            read_additional_calculation_data("qe.out", path_to_file)
+            read_additional_calculation_data(path_to_file, "espresso-out")
         return self.predict_for_atoms(self.data.target_calculator.atoms,
                                       gather_ldos=gather_ldos)
 
@@ -95,8 +95,8 @@ class Predictor(Runner):
 
         # Provide info from current snapshot to target calculator.
         self.data.target_calculator.\
-            read_additional_calculation_data("atoms+grid",
-                                             [atoms, self.data.grid_dimension])
+            read_additional_calculation_data([atoms, self.data.grid_dimension],
+                                             "atoms+grid")
         feature_length = self.data.descriptor_calculator.fingerprint_length
 
         # The actual calculation of the LDOS from the descriptors depends

--- a/mala/network/trainer.py
+++ b/mala/network/trainer.py
@@ -590,8 +590,7 @@ class Trainer(Runner):
                 # This works because the list is always guaranteed to be
                 # ordered.
                 calculator.\
-                    read_additional_calculation_data("qe.out",
-                                                     self.data.get_snapshot_calculation_output(snapshot_number))
+                    read_additional_calculation_data(self.data.get_snapshot_calculation_output(snapshot_number))
                 fe_actual = calculator.\
                     get_self_consistent_fermi_energy(actual_outputs)
                 be_actual = calculator.\
@@ -633,8 +632,7 @@ class Trainer(Runner):
                 # This works because the list is always guaranteed to be
                 # ordered.
                 calculator.\
-                    read_additional_calculation_data("qe.out",
-                                                     self.data.get_snapshot_calculation_output(snapshot_number))
+                    read_additional_calculation_data(self.data.get_snapshot_calculation_output(snapshot_number))
                 fe_actual = calculator.\
                     get_self_consistent_fermi_energy(actual_outputs)
                 te_actual = calculator.\

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -180,7 +180,7 @@ class DOS(Target):
         return_dos = DOS(params)
 
         # In this case, we may just read the entire qe.out file.
-        return_dos.read_additional_calculation_data("qe.out", path)
+        return_dos.read_additional_calculation_data(path, "espresso-out")
 
         # This method will use the ASE atoms object read above automatically.
         return_dos.read_from_qe_out()

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -265,9 +265,9 @@ class Target(PhysicalData):
               .json file.
         """
         if data_type is None:
-            if type(data) == list or type(data) == tuple:
+            if isinstance(data, list) or isinstance(data, tuple):
                 data_type = "atoms+grid"
-            if type(data) == str:
+            elif isinstance(data, str):
                 file_name = os.path.basename(data)
                 file_ending = file_name.split(".")[-1]
                 if file_ending == "out":
@@ -277,6 +277,9 @@ class Target(PhysicalData):
                 else:
                     raise Exception("Could not guess type of additional "
                                     "calculation data provided to MALA.")
+            else:
+                raise Exception("Could not guess type of additional "
+                                "calculation data provided to MALA.")
 
         if data_type == "espresso-out":
             # Reset everything.

--- a/test/inference_test.py
+++ b/test/inference_test.py
@@ -168,9 +168,10 @@ class TestInference:
         tester = Tester(test_parameters, test_network, inference_data_handler)
         actual_ldos, predicted_ldos = tester.test_snapshot(0)
         ldos_calculator = inference_data_handler.target_calculator
-        ldos_calculator.read_additional_calculation_data("qe.out", os.path.join(
+        ldos_calculator.read_additional_calculation_data(os.path.join(
                                                          beryllium_path,
-                                                         "Be_snapshot3.out"))
+                                                         "Be_snapshot3.out"),
+                                                         "espresso-out")
 
         band_energy_tester_class = ldos_calculator.get_band_energy(predicted_ldos)
         nr_electrons_tester_class = ldos_calculator.\
@@ -190,9 +191,10 @@ class TestInference:
         # parameters.
         inference_data_handler. \
             target_calculator.\
-            read_additional_calculation_data("qe.out", os.path.join(
+            read_additional_calculation_data(os.path.join(
                                              beryllium_path,
-                                             "Be_snapshot3.out"))
+                                             "Be_snapshot3.out"),
+                                             "espresso-out")
 
         nr_electrons_predictor_class = inference_data_handler.\
             target_calculator.get_number_of_electrons(predicted_ldos)
@@ -276,9 +278,9 @@ class TestInference:
         ldos_calculator: LDOS
         ldos_calculator = inference_data_handler.target_calculator
         ldos_calculator. \
-            read_additional_calculation_data("qe.out",
-                                             os.path.join(beryllium_path,
-                                                          "Be_snapshot3.out"))
+            read_additional_calculation_data(os.path.join(beryllium_path,
+                                                          "Be_snapshot3.out"),
+                                             "espresso-out")
         ldos_calculator.read_from_array(predicted_ldos)
         total_energy_traditional = ldos_calculator.total_energy
         test_parameters.descriptors.use_atomic_density_energy_formula = True

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -102,7 +102,8 @@ class TestMALAIntegration:
         """
         # Create a calculator.
         dens_calculator = Density(test_parameters)
-        dens_calculator.read_additional_calculation_data("qe.out", path_to_out)
+        dens_calculator.read_additional_calculation_data(path_to_out,
+                                                         "espresso-out")
 
         # Read the input data.
         density_dft = dens_calculator.convert_units(np.load(path_to_dens_npy),
@@ -134,7 +135,7 @@ class TestMALAIntegration:
         """
         # Create a calculator.abs()
         ldos_calculator = LDOS(test_parameters)
-        ldos_calculator.read_additional_calculation_data("qe.out", path_to_out)
+        ldos_calculator.read_additional_calculation_data(path_to_out, "espresso-out")
         dens_calculator = Density.from_ldos_calculator(ldos_calculator)
 
         # Read the input data.
@@ -169,9 +170,9 @@ class TestMALAIntegration:
         The integral of the LDOS over real space grid should yield the DOS.
         """
         ldos_calculator = LDOS(test_parameters)
-        ldos_calculator.read_additional_calculation_data("qe.out", path_to_out)
+        ldos_calculator.read_additional_calculation_data(path_to_out, "espresso-out")
         dos_calculator = DOS(test_parameters)
-        dos_calculator.read_additional_calculation_data("qe.out", path_to_out)
+        dos_calculator.read_additional_calculation_data(path_to_out, "espresso-out")
 
         # Read the input data.
         ldos_dft = ldos_calculator.convert_units(np.load(path_to_ldos_npy),
@@ -192,7 +193,8 @@ class TestMALAIntegration:
     def test_pwevaldos_vs_ppdos(self):
         """Check pp.x DOS vs. pw.x DOS (from eigenvalues in outfile)."""
         dos_calculator = DOS(test_parameters)
-        dos_calculator.read_additional_calculation_data("qe.out", path_to_out)
+        dos_calculator.read_additional_calculation_data(path_to_out,
+                                                        "espresso-out")
 
         dos_from_pp = np.load(path_to_dos_npy)
 

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -123,7 +123,7 @@ class TestInterfaces:
         calculator = mala.MALA(test_parameters, test_network,
                                data_handler,
                                reference_data=
-                                        ["qe.out",
+                                        ["espresso-out",
                                          os.path.join(data_path,
                                                       "Be_snapshot1.out")])
         total_energy_dft_calculation = calculator.data_handler.\
@@ -137,15 +137,15 @@ class TestInterfaces:
         test_parameters = mala.Parameters()
         ldos_calculator = mala.LDOS(test_parameters)
         ldos_calculator.\
-            read_additional_calculation_data("qe.out",
-                                             os.path.join(data_path,
-                                                          "Be_snapshot1.out"))
+            read_additional_calculation_data(os.path.join(data_path,
+                                                          "Be_snapshot1.out"),
+                                             "espresso-out")
         ldos_calculator.\
             write_additional_calculation_data("additional_calculation_data.json")
         new_ldos_calculator = mala.LDOS(test_parameters)
         new_ldos_calculator.\
-            read_additional_calculation_data("json",
-                                             "additional_calculation_data.json")
+            read_additional_calculation_data("additional_calculation_data.json",
+                                             "json")
 
         # Verify that essentially the same info has been loaded.
         assert np.isclose(ldos_calculator.fermi_energy_dft,
@@ -211,9 +211,9 @@ class TestInterfaces:
                             os.path.join(data_path,
                                          "Be_snapshot1.out.npy"))
         ldos_calculator.\
-            read_additional_calculation_data("qe.out",
-                                             os.path.join(data_path,
-                                                          "Be_snapshot1.out"))
+            read_additional_calculation_data(os.path.join(data_path,
+                                                          "Be_snapshot1.out"),
+                                             "espresso-out")
 
         # Write and then read in via OpenPMD and make sure all the info is
         # retained.

--- a/test/workflow_test.py
+++ b/test/workflow_test.py
@@ -54,7 +54,7 @@ class TestFullWorkflow:
 
         # Create a DataConverter, and add snapshots to it.
         data_converter = mala.DataConverter(test_parameters)
-        data_converter.add_snapshot(descriptor_input_type="qe.out",
+        data_converter.add_snapshot(descriptor_input_type="espresso-out",
                                     descriptor_input_path=
                                     os.path.join(data_path_ldos,
                                                  "Be.pw.scf.out"),
@@ -93,8 +93,9 @@ class TestFullWorkflow:
 
         # Create a target calculator to perform postprocessing.
         dos = mala.Target(test_parameters)
-        dos.read_additional_calculation_data("qe.out", os.path.join(
-                                             data_path, "Al.pw.scf.out"))
+        dos.read_additional_calculation_data(os.path.join(
+                                             data_path, "Al.pw.scf.out"),
+                                             "espresso-out")
         dos_data = np.load(os.path.join(data_path, "Al_dos.npy"))
 
         # Calculate energies
@@ -128,9 +129,10 @@ class TestFullWorkflow:
 
         # Create a target calculator to perform postprocessing.
         ldos = mala.Target(test_parameters)
-        ldos.read_additional_calculation_data("qe.out", os.path.join(
+        ldos.read_additional_calculation_data(os.path.join(
                                               data_path_ldos,
-                                               "Be.pw.scf.out"))
+                                               "Be.pw.scf.out"),
+                                              "espresso-out")
         ldos_data = ldos.convert_units(
             np.load(os.path.join(data_path_ldos, "Be_ldos.npy")),
             "1/(eV*Bohr^3)")
@@ -168,8 +170,9 @@ class TestFullWorkflow:
         # Create a target calculator to perform postprocessing.
         ldos = mala.Target(test_parameters)
         dens = mala.Density.from_ldos_calculator(ldos)
-        ldos.read_additional_calculation_data("qe.out", os.path.join(
-                                              data_path_ldos, "Be.pw.scf.out"))
+        ldos.read_additional_calculation_data(os.path.join(
+                                              data_path_ldos, "Be.pw.scf.out"),
+                                              "espresso-out")
         dos_data = np.load(os.path.join(data_path_ldos, "Be_dos.npy"))
         dens_data = dens.convert_units(
             np.load(os.path.join(data_path_ldos, "Be_dens.npy")),
@@ -207,9 +210,9 @@ class TestFullWorkflow:
 
         # Create a target calculator to perform postprocessing.
         ldos = mala.Target(test_parameters)
-        ldos.read_additional_calculation_data("qe.out", os.path.join(
+        ldos.read_additional_calculation_data(os.path.join(
                                               data_path_ldos,
-                                              "Be.pw.scf.out"))
+                                              "Be.pw.scf.out"), "espresso-out")
         ldos_data = ldos.convert_units(
             np.load(os.path.join(data_path_ldos, "Be_ldos.npy")),
             in_units="1/(eV*Bohr^3)")
@@ -329,9 +332,10 @@ class TestFullWorkflow:
                              inference_data_handler)
         actual_ldos, predicted_ldos = tester.test_snapshot(0)
         ldos_calculator = inference_data_handler.target_calculator
-        ldos_calculator.read_additional_calculation_data("qe.out", os.path.join(
+        ldos_calculator.read_additional_calculation_data(os.path.join(
                                                          data_path,
-                                                         "Al.pw.scf.out"))
+                                                         "Al.pw.scf.out"),
+                                                         "espresso-out")
         band_energy_predicted = ldos_calculator.get_band_energy(predicted_ldos)
         band_energy_actual = ldos_calculator.get_band_energy(actual_ldos)
         nr_electrons_predicted = ldos_calculator.\


### PR DESCRIPTION
So instead of "qe.out" it is now called "espresso-out" as it would be in ASE. Further, I made the `data_type` parameter in "read_additional_calculation_data" optional, and MALA will now attempt to determine the type of file automatically. 