### PR TITLE
Uneven splitting across y-dimension

### DIFF
--- a/mala/network/runner.py
+++ b/mala/network/runner.py
@@ -306,7 +306,7 @@ class Runner:
         data_per_snapshot / batch_size will result in an integer division
         without any residual value.
         """
-        new_batch_size = batchsize
+        new_batch_size = min(batchsize, datasize)
         if datasize % new_batch_size != 0:
             while datasize % new_batch_size != 0:
                 new_batch_size += 1


### PR DESCRIPTION
This PR would enable unaligned CPU numbers (Say a 100x100x100 grid with 300 processors) _including_ y-splitting. Up until now this was limited to z-splitting only. 