### PR TITLE
Fix `ValueError` for band energy metric

### DIFF
--- a/mala/network/trainer.py
+++ b/mala/network/trainer.py
@@ -812,25 +812,27 @@ class Trainer(Runner):
                 # ordered.
                 calculator.\
                     read_additional_calculation_data(self.data.get_snapshot_calculation_output(snapshot_number))
-                fe_actual = calculator.\
-                    get_self_consistent_fermi_energy(actual_outputs)
-                be_actual = calculator.\
-                    get_band_energy(actual_outputs, fermi_energy=fe_actual)
 
                 try:
+                    fe_actual = calculator. \
+                        get_self_consistent_fermi_energy(actual_outputs)
+                    be_actual = calculator. \
+                        get_band_energy(actual_outputs, fermi_energy=fe_actual)
+
                     fe_predicted = calculator.\
                         get_self_consistent_fermi_energy(predicted_outputs)
                     be_predicted = calculator.\
                         get_band_energy(predicted_outputs,
                                         fermi_energy=fe_predicted)
+                    errors.append(np.abs(be_predicted - be_actual) *
+                                  (1000 / len(calculator.atoms)))
                 except ValueError:
                     # If the training went badly, it might be that the above
                     # code results in an error, due to the LDOS being so wrong
                     # that the estimation of the self consistent Fermi energy
                     # fails.
-                    be_predicted = float("inf")
-                errors.append(np.abs(be_predicted-be_actual) *
-                              (1000/len(calculator.atoms)))
+                    errors.append(float("inf"))
+
             return np.mean(errors)
         elif validation_type == "total_energy":
             # Get optimal batch size and number of batches per snapshots.
@@ -860,26 +862,28 @@ class Trainer(Runner):
                 # ordered.
                 calculator.\
                     read_additional_calculation_data(self.data.get_snapshot_calculation_output(snapshot_number))
-                fe_actual = calculator.\
-                    get_self_consistent_fermi_energy(actual_outputs)
-                te_actual = calculator.\
-                    get_total_energy(ldos_data=actual_outputs,
-                                     fermi_energy=fe_actual)
 
                 try:
+                    fe_actual = calculator. \
+                        get_self_consistent_fermi_energy(actual_outputs)
+                    te_actual = calculator. \
+                        get_total_energy(ldos_data=actual_outputs,
+                                         fermi_energy=fe_actual)
+
                     fe_predicted = calculator.\
                         get_self_consistent_fermi_energy(predicted_outputs)
                     te_predicted = calculator.\
                         get_total_energy(ldos_data=actual_outputs,
                                          fermi_energy=fe_predicted)
+                    errors.append(np.abs(te_predicted - te_actual) *
+                                  (1000 / len(calculator.atoms)))
+
                 except ValueError:
                     # If the training went badly, it might be that the above
                     # code results in an error, due to the LDOS being so wrong
                     # that the estimation of the self consistent Fermi energy
                     # fails.
-                    te_predicted = float("inf")
-                errors.append(np.abs(te_predicted-te_actual) *
-                              (1000/len(calculator.atoms)))
+                    errors.append(float("inf"))
             return np.mean(errors)
 
         else:


### PR DESCRIPTION
This PR fixes https://github.com/mala-project/mala/issues/427. The reason the bug occured was that the existing safeguard did not include the calculations on the actual, training data LDOS. But if no lazy loading is used, this data is scaled and rescaled as well, so any type of scaling that leads to un-integrable LDOS would throw this error. Simply moving this check into the safeguard restores expected behavior.