### PR TITLE
`clear_data` now default behavior

### DIFF
--- a/examples/ex02_test_network.py
+++ b/examples/ex02_test_network.py
@@ -7,16 +7,9 @@ from mala.datahandling.data_repo import data_repo_path
 data_path = os.path.join(data_repo_path, "Be2")
 
 """
-ex02_test_network.py: Train a network, then use this network 
-to predict the LDOS and then analyze the results of this prediction. This 
-example is structured a little bit different than other examples. It consists 
-of two functions, to show that networks can be saved and reaccessed after being
-trained once. By default, the training function is commented out. A saved 
-network architecture and parameters is provided in this repository, so this 
-example focusses more on the analysis part. Nonetheless, the training can also
-be done by simply uncommenting the function call. Please not that the values 
-calculated at the end will be wrong, because we operate on 0.0025 % of a full 
-DFT simulation cell for this example. 
+ex02_test_network.py: This example shows how a trained network can be tested
+with additional test snapshots. Either execute ex01 before executing this one
+or download the appropriate model from the provided test data repo.
 """
 
 
@@ -40,7 +33,6 @@ parameters.data.use_lazy_loading = True
 # data_splitting_snapshots list is correct.
 # The clear data in front is used because some data is still attached from
 # the training process.
-data_handler.clear_data()
 data_handler.add_snapshot("Be_snapshot2.in.npy", data_path,
                           "Be_snapshot2.out.npy", data_path, "te",
                           calculation_output_file=

--- a/examples/ex11_pass_single_feature.py
+++ b/examples/ex11_pass_single_feature.py
@@ -36,7 +36,6 @@ def load_whole_snapshot():
     # Units: output_units="1/(Ry*Bohr^3)" means that the output (target) data (LDOS) has
     # unit 1/Ry. Rescaled network output, after oscaler.inverse_transform() is
     # applied (see below) will be in 1/eV.
-    data_handler.clear_data()
     data_handler.add_snapshot("Be_snapshot2.in.npy", data_path,
                                         "Be_snapshot2.out.npy", data_path, "te")
     data_handler.prepare_data(reparametrize_scaler=False)

--- a/examples/ex12_run_predictions.py
+++ b/examples/ex12_run_predictions.py
@@ -37,7 +37,7 @@ parameters.descriptors.bispectrum_cutoff = 4.67637
 # of the training data.
 atoms = read(os.path.join(data_path, "Be_snapshot3.out"))
 ldos = predictor.predict_for_atoms(atoms)
-ldos_calculator: mala.LDOS = data_handler.target_calculator
+ldos_calculator: mala.LDOS = predictor.target_calculator
 ldos_calculator.read_from_array(ldos)
 
 printout("Predicted band energy: ",

--- a/mala/datahandling/data_handler.py
+++ b/mala/datahandling/data_handler.py
@@ -50,6 +50,10 @@ class DataHandler(DataHandlerBase):
     output_data_scaler : mala.datahandling.data_scaler.DataScaler
         Used to scale the output data. If None, then one will be created by
         this class.
+
+    clear_data : bool
+        If true (default), the data list will be cleared upon creation of
+        the object.
     """
 
     ##############################
@@ -58,7 +62,7 @@ class DataHandler(DataHandlerBase):
 
     def __init__(self, parameters: Parameters, target_calculator=None,
                  descriptor_calculator=None, input_data_scaler=None,
-                 output_data_scaler=None):
+                 output_data_scaler=None, clear_data=True):
         super(DataHandler, self).__init__(parameters,
                                           target_calculator=target_calculator,
                                           descriptor_calculator=
@@ -99,6 +103,8 @@ class DataHandler(DataHandlerBase):
 
         # Needed for the fast tensor data sets.
         self.mini_batch_size = parameters.running.mini_batch_size
+        if clear_data:
+            self.clear_data()
 
     ##############################
     # Public methods

--- a/mala/network/hyper_opt.py
+++ b/mala/network/hyper_opt.py
@@ -251,7 +251,8 @@ class HyperOpt(ABC):
             loaded_params.data.use_lazy_loading = True
         new_datahandler = DataHandler(loaded_params,
                                       input_data_scaler=loaded_iscaler,
-                                      output_data_scaler=loaded_oscaler)
+                                      output_data_scaler=loaded_oscaler,
+                                      clear_data=False)
         new_datahandler.prepare_data(reparametrize_scaler=False)
 
         return loaded_params, new_datahandler, optimizer_name

--- a/mala/network/runner.py
+++ b/mala/network/runner.py
@@ -140,7 +140,7 @@ class Runner:
         new_datahandler : mala.datahandling.data_handler.DataHandler
             The data handler reconstructed from file.
 
-        new_runner : Runner
+        new_runner : cls
             (Optional) The runner reconstructed from file. For Tester and
             Predictor class, this is just a newly instantiated object.
         """
@@ -177,7 +177,8 @@ class Runner:
         loaded_oscaler = DataScaler.load_from_file(loaded_oscaler)
         new_datahandler = DataHandler(loaded_params,
                                       input_data_scaler=loaded_iscaler,
-                                      output_data_scaler=loaded_oscaler)
+                                      output_data_scaler=loaded_oscaler,
+                                      clear_data=(not prepare_data))
         if loaded_info is not None:
             new_datahandler.target_calculator.\
                 read_additional_calculation_data(loaded_info,

--- a/test/inference_test.py
+++ b/test/inference_test.py
@@ -26,7 +26,6 @@ class TestInference:
         parameters.data.use_lazy_loading = False
         parameters.running.mini_batch_size = 50
 
-        data_handler.clear_data()
         data_handler.add_snapshot("Be_snapshot0.in.npy", data_path,
                                             "Be_snapshot0.out.npy", data_path,
                                             "te")
@@ -91,7 +90,6 @@ class TestInference:
         parameters.data.use_lazy_loading = use_lazy_loading
         parameters.running.mini_batch_size = batchsize
 
-        data_handler.clear_data()
         data_handler.add_snapshot("Be_snapshot0.in.npy", data_path,
                                   "Be_snapshot0.out.npy", data_path,
                                   "te")

--- a/test/lazy_loading_test.py
+++ b/test/lazy_loading_test.py
@@ -66,7 +66,6 @@ class TestLazyLoading:
                 test_parameters.data.input_rescaling_type = scalingtype
                 test_parameters.data.output_rescaling_type = scalingtype
                 data_handler = DataHandler(test_parameters)
-                data_handler.clear_data()
                 data_handler.add_snapshot("Be_snapshot0.in.npy", data_path,
                                           "Be_snapshot0.out.npy", data_path,
                                           "tr")
@@ -202,7 +201,6 @@ class TestLazyLoading:
                 test_parameters.data.use_lazy_loading = ll
                 test_parameters.use_horovod = hvduse
                 data_handler = DataHandler(test_parameters)
-                data_handler.clear_data()
                 data_handler.add_snapshot("Al_debug_2k_nr0.in.npy", data_path,
                                           "Al_debug_2k_nr0.out.npy", data_path,
                                           add_snapshot_as="tr",

--- a/test/shuffling_test.py
+++ b/test/shuffling_test.py
@@ -95,7 +95,6 @@ class TestDataShuffling:
 
         # Train with shuffling.
         data_handler = mala.DataHandler(test_parameters)
-        data_handler.clear_data()
         # Add a snapshot we want to use in to the list.
         data_handler.add_snapshot("Be_shuffled0.in.npy", ".",
                                   "Be_shuffled0.out.npy", ".", "tr")

--- a/test/workflow_test.py
+++ b/test/workflow_test.py
@@ -244,7 +244,6 @@ class TestFullWorkflow:
         parameters.targets.ldos_gridoffset_ev = -5
         parameters.data.use_lazy_loading = True
 
-        data_handler.clear_data()
         data_handler.add_snapshot("Be_snapshot2.in.npy", data_path,
                                   "Be_snapshot2.out.npy", data_path, "te",
                                   calculation_output_file=os.path.join(
@@ -291,7 +290,6 @@ class TestFullWorkflow:
         parameters.descriptors.bispectrum_cutoff = 4.67637
         parameters.data.use_lazy_loading = True
 
-        data_handler.clear_data()
         data_handler.add_snapshot("Be_snapshot3.in.npy",
                                   data_path,
                                   "Be_snapshot3.out.npy",


### PR DESCRIPTION
This PR makes clear_data() the default behavior of the DataHandler initialization process. This makes testing and predicting way more robust w.r.t to small typing errors.