### PR TITLE
Save and load training data in FP32

### DIFF
--- a/mala/common/parameters.py
+++ b/mala/common/parameters.py
@@ -10,13 +10,15 @@ try:
     import horovod.torch as hvd
 except ModuleNotFoundError:
     pass
-
+import numpy as np
 import torch
 
 from mala.common.parallelizer import printout, set_horovod_status, \
     set_mpi_status, get_rank, get_local_rank, set_current_verbosity, \
     parallel_warn
 from mala.common.json_serializable import JSONSerializable
+
+DEFAULT_NP_DATA_DTYPE = np.float32
 
 
 class ParametersBase(JSONSerializable):

--- a/mala/datahandling/data_handler.py
+++ b/mala/datahandling/data_handler.py
@@ -715,7 +715,8 @@ class DataHandler(DataHandlerBase):
                     # follows does NOT load it into memory, see
                     # test/tensor_memory.py
                     tmp = np.array(tmp)
-                    tmp = tmp.astype(np.float32)
+                    if tmp.dtype != np.float32:
+                        tmp = tmp.astype(np.float32)
                     tmp = tmp.reshape([snapshot.grid_size,
                                        self.input_dimension])
                     tmp = torch.from_numpy(tmp).float()
@@ -766,7 +767,8 @@ class DataHandler(DataHandlerBase):
                     # follows does NOT load it into memory, see
                     # test/tensor_memory.py
                     tmp = np.array(tmp)
-                    tmp = tmp.astype(np.float32)
+                    if tmp.dtype != np.float32:
+                        tmp = tmp.astype(np.float32)
                     tmp = tmp.reshape([snapshot.grid_size,
                                        self.output_dimension])
                     tmp = torch.from_numpy(tmp).float()

--- a/mala/datahandling/data_handler.py
+++ b/mala/datahandling/data_handler.py
@@ -11,15 +11,13 @@ import torch
 from torch.utils.data import TensorDataset
 
 from mala.common.parallelizer import printout, barrier
-from mala.common.parameters import Parameters
+from mala.common.parameters import Parameters, DEFAULT_NP_DATA_DTYPE
 from mala.datahandling.data_handler_base import DataHandlerBase
 from mala.datahandling.data_scaler import DataScaler
 from mala.datahandling.snapshot import Snapshot
 from mala.datahandling.lazy_load_dataset import LazyLoadDataset
 from mala.datahandling.lazy_load_dataset_clustered import \
     LazyLoadDatasetClustered
-from mala.descriptors.descriptor import Descriptor
-from mala.targets.target import Target
 from mala.datahandling.fast_tensor_dataset import FastTensorDataset
 
 
@@ -448,26 +446,26 @@ class DataHandler(DataHandlerBase):
         if self.nr_training_data > 0:
             self.training_data_inputs = np.zeros((self.nr_training_data,
                                                   self.input_dimension),
-                                                 dtype=np.float32)
+                                                 dtype=DEFAULT_NP_DATA_DTYPE)
             self.training_data_outputs = np.zeros((self.nr_training_data,
                                                    self.output_dimension),
-                                                  dtype=np.float32)
+                                                  dtype=DEFAULT_NP_DATA_DTYPE)
 
         if self.nr_validation_data > 0:
             self.validation_data_inputs = np.zeros((self.nr_validation_data,
                                                     self.input_dimension),
-                                                   dtype=np.float32)
+                                                   dtype=DEFAULT_NP_DATA_DTYPE)
             self.validation_data_outputs = np.zeros((self.nr_validation_data,
                                                      self.output_dimension),
-                                                    dtype=np.float32)
+                                                    dtype=DEFAULT_NP_DATA_DTYPE)
 
         if self.nr_test_data > 0:
             self.test_data_inputs = np.zeros((self.nr_test_data,
                                               self.input_dimension),
-                                             dtype=np.float32)
+                                             dtype=DEFAULT_NP_DATA_DTYPE)
             self.test_data_outputs = np.zeros((self.nr_test_data,
                                                self.output_dimension),
-                                              dtype=np.float32)
+                                              dtype=DEFAULT_NP_DATA_DTYPE)
 
     def __load_data(self, function, data_type):
         """
@@ -715,8 +713,8 @@ class DataHandler(DataHandlerBase):
                     # follows does NOT load it into memory, see
                     # test/tensor_memory.py
                     tmp = np.array(tmp)
-                    if tmp.dtype != np.float32:
-                        tmp = tmp.astype(np.float32)
+                    if tmp.dtype != DEFAULT_NP_DATA_DTYPE:
+                        tmp = tmp.astype(DEFAULT_NP_DATA_DTYPE)
                     tmp = tmp.reshape([snapshot.grid_size,
                                        self.input_dimension])
                     tmp = torch.from_numpy(tmp).float()
@@ -767,8 +765,8 @@ class DataHandler(DataHandlerBase):
                     # follows does NOT load it into memory, see
                     # test/tensor_memory.py
                     tmp = np.array(tmp)
-                    if tmp.dtype != np.float32:
-                        tmp = tmp.astype(np.float32)
+                    if tmp.dtype != DEFAULT_NP_DATA_DTYPE:
+                        tmp = tmp.astype(DEFAULT_NP_DATA_DTYPE)
                     tmp = tmp.reshape([snapshot.grid_size,
                                        self.output_dimension])
                     tmp = torch.from_numpy(tmp).float()
@@ -810,7 +808,7 @@ class DataHandler(DataHandlerBase):
         This tensor that can simply be put into a MALA network.
         No unit conversion is done here.
         """
-        numpy_array = numpy_array.astype(np.float32)
+        numpy_array = numpy_array.astype(DEFAULT_NP_DATA_DTYPE)
         if desired_dimensions is not None:
             numpy_array = numpy_array.reshape(desired_dimensions)
         numpy_array = torch.from_numpy(numpy_array).float()

--- a/mala/datahandling/lazy_load_dataset.py
+++ b/mala/datahandling/lazy_load_dataset.py
@@ -11,6 +11,7 @@ import torch
 from torch.utils.data import Dataset
 
 from mala.common.parallelizer import barrier
+from mala.common.parameters import DEFAULT_NP_DATA_DTYPE
 from mala.datahandling.snapshot import Snapshot
 
 
@@ -153,8 +154,8 @@ class LazyLoadDataset(torch.utils.data.Dataset):
         self.input_data = \
             self.input_data.reshape([self.snapshot_list[file_index].grid_size,
                                      self.input_dimension])
-        if self.input_data.dtype != np.float32:
-            self.input_data = self.input_data.astype(np.float32)
+        if self.input_data.dtype != DEFAULT_NP_DATA_DTYPE:
+            self.input_data = self.input_data.astype(DEFAULT_NP_DATA_DTYPE)
         self.input_data = torch.from_numpy(self.input_data).float()
         self.input_data_scaler.transform(self.input_data)
         self.input_data.requires_grad = self.input_requires_grad
@@ -164,8 +165,8 @@ class LazyLoadDataset(torch.utils.data.Dataset):
                                       self.output_dimension])
         if self.return_outputs_directly is False:
             self.output_data = np.array(self.output_data)
-            if self.output_data.dtype != np.float32:
-                self.output_data = self.output_data.astype(np.float32)
+            if self.output_data.dtype != DEFAULT_NP_DATA_DTYPE:
+                self.output_data = self.output_data.astype(DEFAULT_NP_DATA_DTYPE)
             self.output_data = torch.from_numpy(self.output_data).float()
             self.output_data_scaler.transform(self.output_data)
 

--- a/mala/datahandling/lazy_load_dataset.py
+++ b/mala/datahandling/lazy_load_dataset.py
@@ -153,7 +153,8 @@ class LazyLoadDataset(torch.utils.data.Dataset):
         self.input_data = \
             self.input_data.reshape([self.snapshot_list[file_index].grid_size,
                                      self.input_dimension])
-        self.input_data = self.input_data.astype(np.float32)
+        if self.input_data.dtype != np.float32:
+            self.input_data = self.input_data.astype(np.float32)
         self.input_data = torch.from_numpy(self.input_data).float()
         self.input_data_scaler.transform(self.input_data)
         self.input_data.requires_grad = self.input_requires_grad
@@ -163,7 +164,8 @@ class LazyLoadDataset(torch.utils.data.Dataset):
                                       self.output_dimension])
         if self.return_outputs_directly is False:
             self.output_data = np.array(self.output_data)
-            self.output_data = self.output_data.astype(np.float32)
+            if self.output_data.dtype != np.float32:
+                self.output_data = self.output_data.astype(np.float32)
             self.output_data = torch.from_numpy(self.output_data).float()
             self.output_data_scaler.transform(self.output_data)
 

--- a/mala/datahandling/lazy_load_dataset_clustered.py
+++ b/mala/datahandling/lazy_load_dataset_clustered.py
@@ -12,6 +12,7 @@ import torch
 from torch.utils.data import Dataset
 
 from mala.datahandling.snapshot import Snapshot
+from mala.common.parameters import DEFAULT_NP_DATA_DTYPE
 from mala.common.parallelizer import printout, barrier
 
 
@@ -142,8 +143,8 @@ class LazyLoadDatasetClustered(torch.utils.data.Dataset):
         # Transform the data.
         input_data = input_data.reshape([self.grid_size, self.input_dimension])
 
-        if self.input_data.dtype != np.float32:
-            self.input_data = self.input_data.astype(np.float32)
+        if self.input_data.dtype != DEFAULT_NP_DATA_DTYPE:
+            self.input_data = self.input_data.astype(DEFAULT_NP_DATA_DTYPE)
         input_data = torch.from_numpy(input_data).float()
         self.input_data_scaler.transform(input_data)
         input_data = np.array(input_data)
@@ -275,8 +276,8 @@ class LazyLoadDatasetClustered(torch.utils.data.Dataset):
         # Transform the data.
         self.input_data = \
             self.input_data.reshape([self.grid_size, self.input_dimension])
-        if self.input_data.dtype != np.float32:
-            self.input_data = self.input_data.astype(np.float32)
+        if self.input_data.dtype != DEFAULT_NP_DATA_DTYPE:
+            self.input_data = self.input_data.astype(DEFAULT_NP_DATA_DTYPE)
         self.input_data = torch.from_numpy(self.input_data).float()
         self.input_data_scaler.transform(self.input_data)
         self.input_data.requires_grad = self.input_requires_grad
@@ -288,8 +289,8 @@ class LazyLoadDatasetClustered(torch.utils.data.Dataset):
             convert_units(1, self.snapshot_list[file_index].output_units)
         if self.return_outputs_directly is False:
             self.output_data = np.array(self.output_data)
-            if self.output_data.dtype != np.float32:
-                self.output_data = self.output_data.astype(np.float32)
+            if self.output_data.dtype != DEFAULT_NP_DATA_DTYPE:
+                self.output_data = self.output_data.astype(DEFAULT_NP_DATA_DTYPE)
             self.output_data = torch.from_numpy(self.output_data).float()
             self.output_data_scaler.transform(self.output_data)
 

--- a/mala/datahandling/lazy_load_dataset_clustered.py
+++ b/mala/datahandling/lazy_load_dataset_clustered.py
@@ -140,13 +140,10 @@ class LazyLoadDatasetClustered(torch.utils.data.Dataset):
                                  input_npy_file)
         input_data = np.load(file_path)
         # Transform the data.
-        if self.descriptors_contain_xyz:
-            input_data = input_data[:, :, :, 3:]
         input_data = input_data.reshape([self.grid_size, self.input_dimension])
-        input_data *= \
-            self.descriptor_calculator.\
-            convert_units(1, self.snapshot_list[snapshot_idx].input_units)
-        input_data = input_data.astype(np.float32)
+
+        if self.input_data.dtype != np.float32:
+            self.input_data = self.input_data.astype(np.float32)
         input_data = torch.from_numpy(input_data).float()
         self.input_data_scaler.transform(input_data)
         input_data = np.array(input_data)
@@ -276,14 +273,10 @@ class LazyLoadDatasetClustered(torch.utils.data.Dataset):
                              self.snapshot_list[file_index].output_npy_file))
 
         # Transform the data.
-        if self.descriptors_contain_xyz:
-            self.input_data = self.input_data[:, :, :, 3:]
         self.input_data = \
             self.input_data.reshape([self.grid_size, self.input_dimension])
-        self.input_data *= \
-            self.descriptor_calculator.\
-            convert_units(1, self.snapshot_list[file_index].input_units)
-        self.input_data = self.input_data.astype(np.float32)
+        if self.input_data.dtype != np.float32:
+            self.input_data = self.input_data.astype(np.float32)
         self.input_data = torch.from_numpy(self.input_data).float()
         self.input_data_scaler.transform(self.input_data)
         self.input_data.requires_grad = self.input_requires_grad
@@ -295,7 +288,8 @@ class LazyLoadDatasetClustered(torch.utils.data.Dataset):
             convert_units(1, self.snapshot_list[file_index].output_units)
         if self.return_outputs_directly is False:
             self.output_data = np.array(self.output_data)
-            self.output_data = self.output_data.astype(np.float32)
+            if self.output_data.dtype != np.float32:
+                self.output_data = self.output_data.astype(np.float32)
             self.output_data = torch.from_numpy(self.output_data).float()
             self.output_data_scaler.transform(self.output_data)
 

--- a/mala/descriptors/atomic_density.py
+++ b/mala/descriptors/atomic_density.py
@@ -119,15 +119,8 @@ class AtomicDensity(Descriptor):
 
     def _calculate(self, atoms, outdir, grid_dimensions, **kwargs):
         """Perform actual Gaussian descriptor calculation."""
-        from lammps import lammps
-        if "use_fp64" in kwargs.keys():
-            use_fp64 = kwargs["use_fp64"]
-        else:
-            use_fp64 = False
-
-        return_directly = False
-        if "return_directly" in kwargs.keys():
-            return_directly = kwargs["return_directly"]
+        use_fp64 = kwargs.get("use_fp64", False)
+        return_directly = kwargs.get("return_directly", False)
 
         lammps_format = "lammps-data"
         ase_out_path = os.path.join(outdir, "lammps_input.tmp")

--- a/mala/descriptors/atomic_density.py
+++ b/mala/descriptors/atomic_density.py
@@ -120,6 +120,10 @@ class AtomicDensity(Descriptor):
     def _calculate(self, atoms, outdir, grid_dimensions, **kwargs):
         """Perform actual Gaussian descriptor calculation."""
         from lammps import lammps
+        if "use_fp64" in kwargs.keys():
+            use_fp64 = kwargs["use_fp64"]
+        else:
+            use_fp64 = False
 
         return_directly = False
         if "return_directly" in kwargs.keys():
@@ -183,7 +187,8 @@ class AtomicDensity(Descriptor):
         gaussian_descriptors_np = \
             extract_compute_np(lmp, "ggrid",
                                lammps_constants.LMP_STYLE_LOCAL, 2,
-                               array_shape=(nrows_ggrid, ncols_ggrid))
+                               array_shape=(nrows_ggrid, ncols_ggrid),
+                               use_fp64=use_fp64)
 
         # In comparison to SNAP, the atomic density always returns
         # in the "local mode". Thus we have to make some slight adjustments

--- a/mala/descriptors/bispectrum.py
+++ b/mala/descriptors/bispectrum.py
@@ -175,12 +175,6 @@ class Bispectrum(Descriptor):
 
             # Copy the grid dimensions only at the end.
             self.grid_dimensions = [nx, ny, nz]
-
-            # If I directly return the descriptors, this sometimes leads
-            # to errors, because presumably the python garbage collection
-            # deallocates memory too quickly. This copy is more memory
-            # hungry, and we might have to tackle this later on, but
-            # for now it works.
             return snap_descriptors_np, nrows_local
 
         else:
@@ -194,14 +188,6 @@ class Bispectrum(Descriptor):
             snap_descriptors_np = snap_descriptors_np.transpose([2, 1, 0, 3])
             # Copy the grid dimensions only at the end.
             self.grid_dimensions = [nx, ny, nz]
-            # If I directly return the descriptors, this sometimes leads
-            # to errors, because presumably the python garbage collection
-            # deallocates memory too quickly. This copy is more memory
-            # hungry, and we might have to tackle this later on, but
-            # for now it works.
-            # I thought the transpose would take care of that, but apparently
-            # it does not necessarily do that - so we have do go down
-            # that route.
             if self.parameters.descriptors_contain_xyz:
                 return snap_descriptors_np, nx*ny*nz
             else:

--- a/mala/descriptors/bispectrum.py
+++ b/mala/descriptors/bispectrum.py
@@ -93,10 +93,7 @@ class Bispectrum(Descriptor):
     def _calculate(self, atoms, outdir, grid_dimensions, **kwargs):
         """Perform actual bispectrum calculation."""
         from lammps import lammps
-        if "use_fp64" in kwargs.keys():
-            use_fp64 = kwargs["use_fp64"]
-        else:
-            use_fp64 = False
+        use_fp64 = kwargs.get("use_fp64", False)
 
         lammps_format = "lammps-data"
         ase_out_path = os.path.join(outdir, "lammps_input.tmp")

--- a/mala/descriptors/descriptor.py
+++ b/mala/descriptors/descriptor.py
@@ -332,7 +332,7 @@ class Descriptor(PhysicalData):
                 for i in range(0, get_size()):
                     all_descriptors_list.append(
                         np.empty(sendcounts[i] * raw_feature_length,
-                                 dtype=np.float64))
+                                 dtype=descriptors_np.dtype))
 
                 # No MPI necessary for first rank. For all the others,
                 # collect the buffers.

--- a/mala/descriptors/lammps_utils.py
+++ b/mala/descriptors/lammps_utils.py
@@ -3,6 +3,8 @@ import ctypes
 
 import numpy as np
 
+from mala.common.parameters import DEFAULT_NP_DATA_DTYPE
+
 
 def set_cmdlinevars(cmdargs, argdict):
     """
@@ -85,7 +87,7 @@ def extract_compute_np(lmp, name, compute_type, result_type, array_shape=None,
         if use_fp64:
             return array_np.copy()
         else:
-            return array_np.astype(np.float32)
+            return array_np.astype(DEFAULT_NP_DATA_DTYPE)
     if result_type == 4 or result_type == 5:
         # ptr is an int
         return ptr

--- a/mala/descriptors/lammps_utils.py
+++ b/mala/descriptors/lammps_utils.py
@@ -72,6 +72,16 @@ def extract_compute_np(lmp, name, compute_type, result_type, array_shape=None,
                                                      total_size))
         array_np = np.frombuffer(buffer_ptr.contents, dtype=float)
         array_np.shape = array_shape
+        # If I directly return the descriptors, this sometimes leads
+        # to errors, because presumably the python garbage collection
+        # deallocates memory too quickly. This copy is more memory
+        # hungry, and we might have to tackle this later on, but
+        # for now it works.
+        # I thought the transpose would take care of that, but apparently
+        # it does not necessarily do that - so we have do go down
+        # that route.
+        # If we have to modify the data type, the copy becomes redundant,
+        # since .astype always copies.
         if use_fp64:
             return array_np.copy()
         else:

--- a/mala/descriptors/lammps_utils.py
+++ b/mala/descriptors/lammps_utils.py
@@ -29,7 +29,8 @@ def set_cmdlinevars(cmdargs, argdict):
 #     return [x for x in string.splitlines() if x.strip() != '']
 
 
-def extract_compute_np(lmp, name, compute_type, result_type, array_shape=None):
+def extract_compute_np(lmp, name, compute_type, result_type, array_shape=None,
+                       use_fp64=False):
     """
     Convert a lammps compute to a numpy array.
 
@@ -55,6 +56,10 @@ def extract_compute_np(lmp, name, compute_type, result_type, array_shape=None):
     array_shape
         Array shape of the LAMMPS calculation.
 
+    use_fp64 : bool
+        If True, return the array with double precision. If False (default),
+        the array will be processed with single precision. Only has an effect
+        if result_type equals 2.
     """
     # 1,2: Style (1) is per-atom compute, returns array type (2).
     ptr = lmp.extract_compute(name, compute_type, result_type)
@@ -67,7 +72,10 @@ def extract_compute_np(lmp, name, compute_type, result_type, array_shape=None):
                                                      total_size))
         array_np = np.frombuffer(buffer_ptr.contents, dtype=float)
         array_np.shape = array_shape
-        return array_np
+        if use_fp64:
+            return array_np.copy()
+        else:
+            return array_np.astype(np.float32)
     if result_type == 4 or result_type == 5:
         # ptr is an int
         return ptr

--- a/mala/network/predictor.py
+++ b/mala/network/predictor.py
@@ -166,8 +166,6 @@ class Predictor(Runner):
                                     " for parallel inference")
 
                 snap_descriptors = \
-                    snap_descriptors.astype(np.float32)
-                snap_descriptors = \
                     torch.from_numpy(snap_descriptors).float()
                 self.data.input_data_scaler.transform(snap_descriptors)
                 return self. \
@@ -178,8 +176,6 @@ class Predictor(Runner):
                 snap_descriptors = snap_descriptors[:, :, :, 3:]
                 feature_length -= 3
 
-            snap_descriptors = \
-                snap_descriptors.astype(np.float32)
             snap_descriptors = \
                 snap_descriptors.reshape(
                     [self.data.grid_size, feature_length])

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -1057,6 +1057,6 @@ class Density(Target):
 
     def _get_gaussian_descriptors_for_structure_factors(self, atoms, grid):
         descriptor_calculator = AtomicDensity(self._parameters_full)
-        kwargs = {"return_directly": True}
+        kwargs = {"return_directly": True, "use_fp64": True}
         return descriptor_calculator.\
             calculate_from_atoms(atoms, grid, **kwargs)[:, 6:]

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -1347,12 +1347,8 @@ class LDOS(Target):
             Usage will reduce RAM footprint while SIGNIFICANTLY
             impacting disk usage and
         """
-        return_local = False
-        if "return_local" in kwargs.keys():
-            return_local = kwargs["return_local"]
-        use_fp64 = False
-        if "use_fp64" in kwargs.keys():
-            use_fp64 = kwargs["use_fp64"]
+        use_fp64 = kwargs.get("use_fp64", False)
+        return_local = kwargs.get("return_local", False)
         ldos_dtype = np.float64 if use_fp64 else DEFAULT_NP_DATA_DTYPE
 
         # Find out the number of digits that are needed to encode this

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -8,6 +8,7 @@ from scipy import integrate
 
 from mala.common.parallelizer import get_comm, printout, get_rank, get_size, \
     barrier
+from mala.common.parameters import DEFAULT_NP_DATA_DTYPE
 from mala.targets.cube_parser import read_cube
 from mala.targets.xsf_parser import read_xsf
 from mala.targets.target import Target
@@ -1352,7 +1353,7 @@ class LDOS(Target):
         use_fp64 = False
         if "use_fp64" in kwargs.keys():
             use_fp64 = kwargs["use_fp64"]
-        ldos_dtype = np.float64 if use_fp64 else np.float32
+        ldos_dtype = np.float64 if use_fp64 else DEFAULT_NP_DATA_DTYPE
 
         # Find out the number of digits that are needed to encode this
         # grid (by QE).

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -1163,10 +1163,12 @@ class LDOS(Target):
                 dos_values *= grid_spacing_z
         else:
             if len(ldos_data_shape) == 4:
-                dos_values = np.sum(ldos_data, axis=(0, 1, 2)) * \
+                dos_values = np.sum(ldos_data, axis=(0, 1, 2),
+                                    dtype=np.float64) * \
                              voxel.volume
             if len(ldos_data_shape) == 2:
-                dos_values = np.sum(ldos_data, axis=0) * \
+                dos_values = np.sum(ldos_data, axis=0,
+                                    dtype=np.float64) * \
                              voxel.volume
 
         if self.parameters._configuration["mpi"] and gather_dos:


### PR DESCRIPTION
Since pytorch operates with FP32 anyway, it would be a good idea to have the data saved in FP32 too. This seemed like a problem since LDOS integration seemed to go wrong when performed with FP32 data, but this was an oversight in the usage of the `np.sum` function. This PR fixes this, closes #433 and allows for native training data conversion into FP32. FP64 conversion is supported as legacy option. 