### PR TITLE
Generalize Tester class to test training and validation partitions

### DIFF
--- a/mala/network/tester.py
+++ b/mala/network/tester.py
@@ -94,7 +94,7 @@ class Tester(Runner):
         else:
             raise Exception("Wrong output format for testing selected.")
 
-    def test_snapshot(self, snapshot_number):
+    def test_snapshot(self, snapshot_number, data_type='te'):
         """
         Test the selected observables for a single snapshot.
 
@@ -103,13 +103,16 @@ class Tester(Runner):
         snapshot_number : int
             Snapshot which to test.
 
+        data_type : str
+            'tr', 'va', or 'te' indicating the partition to be tested
+
         Returns
         -------
         results : dict
             A dictionary containing the errors for the selected observables.
         """
         actual_outputs, predicted_outputs = \
-            self.predict_targets(snapshot_number)
+            self.predict_targets(snapshot_number, data_type=data_type)
 
         results = {}
         for observable in self.observables_to_test:
@@ -119,7 +122,7 @@ class Tester(Runner):
                                              actual_outputs)
         return results
 
-    def predict_targets(self, snapshot_number, data_type):
+    def predict_targets(self, snapshot_number, data_type='te'):
         """
         Get actual and predicted output for a snapshot.
 

--- a/mala/network/tester.py
+++ b/mala/network/tester.py
@@ -154,9 +154,9 @@ class Tester(Runner):
         elif data_type == 'te':
             offset_snapshots += self.data.nr_validation_snapshots + \
                                 self.data.nr_training_snapshots
-        data_sets = {'tr': self.data.training_data_set,
-                     'va': self.data.validation_data_set,
-                     'te': self.data.test_data_set}
+        data_sets = {'tr': self.data.training_data_sets[0],
+                     'va': self.data.validation_data_sets[0],
+                     'te': self.data.test_data_sets[0]}
 
         # Forward through network.
         return self.\

--- a/mala/network/tester.py
+++ b/mala/network/tester.py
@@ -146,22 +146,23 @@ class Tester(Runner):
         self.__prepare_to_test(snapshot_number)
         # Make sure no data lingers in the target calculator.
         self.data.target_calculator.invalidate_target()
-        
         # Select the inputs used for prediction
-        offset_snapshots = 0
-        if data_type == 'va':
-            offset_snapshots += self.data.nr_training_snapshots
+        if data_type == 'tr':
+            offset_snapshots = 0
+            data_set = self.data.training_data_sets[0]
+        elif data_type == 'va':
+            offset_snapshots = self.data.nr_training_snapshots
+            data_set = self.data.validation_data_sets[0]
         elif data_type == 'te':
-            offset_snapshots += self.data.nr_validation_snapshots + \
-                                self.data.nr_training_snapshots
-        data_sets = {'tr': self.data.training_data_sets[0],
-                     'va': self.data.validation_data_sets[0],
-                     'te': self.data.test_data_sets[0]}
-
+            offset_snapshots = self.data.nr_validation_snapshots + \
+                               self.data.nr_training_snapshots
+            data_set = self.data.test_data_sets[0]
+        else:
+            raise ValueError(f"Invalid data_type: {data_type} -- Valid options are tr, va, te.")
         # Forward through network.
         return self.\
             _forward_entire_snapshot(offset_snapshots+snapshot_number,
-                                     data_sets[data_type],
+                                     data_set,
                                      data_type,
                                      self.number_of_batches_per_snapshot,
                                      self.parameters.mini_batch_size)


### PR DESCRIPTION
Added an optional argument to predict_targets() and test_snapshot() allowing the user to specify 'tr' and 'va' partitions for testing.

This allows the user to easily calculate unscaled training and validation predictions for comparing accuracy between data set partitions. 