### PR TITLE
For LDOS and density, the grid dimensions are now read

### DIFF
--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -396,6 +396,7 @@ class Density(Target):
         data, meta = read_cube(path)
         data *= self.convert_units(1, in_units=units)
         self.density = data
+        self.grid_dimensions = np.shape(data)[0:3]
         return data
 
     def read_from_xsf(self, path, units="1/A^3", **kwargs):

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -1397,6 +1397,7 @@ class LDOS(Target):
             # Convert and then append the LDOS data.
             data = data*self.convert_units(1, in_units=units)
             ldos_data[:, :, :, i-start_index] = data[:, :, :]
+            self.grid_dimensions = np.shape(ldos_data)[0:3]
 
         # We have to gather the LDOS either file based or not.
         if self.parameters._configuration["mpi"]:


### PR DESCRIPTION
For LDOS and density, the grid dimensions are now read alongside raw ab-initio data. 