### PR TITLE
[WIP] Enabling GPU calculation of descriptors via LAMMPS

### DIFF
--- a/mala/descriptors/atomic_density.py
+++ b/mala/descriptors/atomic_density.py
@@ -140,12 +140,8 @@ class AtomicDensity(Descriptor):
             self.parameters.atomic_density_sigma = self.\
                 get_optimal_sigma(voxel)
 
-        # Build LAMMPS arguments from the data we read.
-        lmp_cmdargs = ["-screen", "none", "-log",
-                       os.path.join(outdir, "lammps_ggrid_log.tmp")]
-
         # LAMMPS processor grid filled by parent class.
-        lammps_dict = self._setup_lammps_processors(nx, ny, nz)
+        lammps_dict, lmp_cmdargs = self._setup_lammps(nx, ny, nz, outdir)
 
         # Set the values not already filled in the LAMMPS setup.
         lammps_dict["sigma"] = self.parameters.atomic_density_sigma

--- a/mala/descriptors/bispectrum.py
+++ b/mala/descriptors/bispectrum.py
@@ -104,11 +104,10 @@ class Bispectrum(Descriptor):
         nz = grid_dimensions[2]
 
         # Build LAMMPS arguments from the data we read.
-        lmp_cmdargs = ["-screen", "none", "-log",
-                       os.path.join(outdir, "lammps_bgrid_log.tmp")]
 
         # LAMMPS processor grid filled by parent class.
-        lammps_dict = self._setup_lammps_processors(nx, ny, nz)
+        lammps_dict, lmp_cmdargs = self._setup_lammps(nx, ny, nz,
+                                                      outdir)
 
         # Set the values not already filled in the LAMMPS setup.
         lammps_dict["twojmax"] = self.parameters.bispectrum_twojmax

--- a/mala/descriptors/bispectrum.py
+++ b/mala/descriptors/bispectrum.py
@@ -132,8 +132,12 @@ class Bispectrum(Descriptor):
                         os.path.join(filepath,
                                      "in.bgridlocal_defaultproc.python")
             else:
-                self.parameters.lammps_compute_file = \
-                    os.path.join(filepath, "in.bgrid.python")
+                if self.parameters._configuration["gpu"]:
+                    self.parameters.lammps_compute_file = \
+                        os.path.join(filepath, "in.bgrid_kokkos.python")
+                else:
+                    self.parameters.lammps_compute_file = \
+                        os.path.join(filepath, "in.bgrid.python")
 
         # Do the LAMMPS calculation.
         lmp.file(self.parameters.lammps_compute_file)

--- a/mala/descriptors/descriptor.py
+++ b/mala/descriptors/descriptor.py
@@ -697,8 +697,9 @@ class Descriptor(PhysicalData):
                            "switch": self.parameters.bispectrum_switchflag}
             if self.parameters._configuration["gpu"]:
                 # Tell Kokkos to use one GPU.
-                lmp_cmdargs.append("-k")
-                lmp_cmdargs.append("on g 1")
+                # lmp_cmdargs.append("-k")
+                # lmp_cmdargs.append("on g 1")
+                pass
 
         return lammps_dict, lmp_cmdargs
 

--- a/mala/descriptors/in.bgrid_kokkos.python
+++ b/mala/descriptors/in.bgrid_kokkos.python
@@ -1,0 +1,40 @@
+# Calculate SNAP descriptors on a 3D grid
+
+# pass in values ngridx, ngridy, ngridz, twojmax, rcutfac, atom_config_fname 
+# using command-line -var option
+
+# Initialize simulation
+
+units		metal
+
+read_data ${atom_config_fname}
+mass * 1.0
+
+# Needs to be defined for Kokkos
+run_style verlet/kk
+
+# define grid compute and atom compute
+
+group 		snapgroup type 1
+variable 	rfac0 equal 0.99363
+variable 	rmin0 equal 0
+variable 	wj equal 1
+variable 	radelem equal 0.5
+variable 	bzero equal 0
+variable 	quadratic equal 0
+
+compute bgrid all sna/grid grid ${ngridx} ${ngridy} ${ngridz} ${rcutfac} ${rfac0} ${twojmax} ${radelem} ${wj} rmin0 ${rmin0} bzeroflag ${bzero} quadraticflag ${quadratic} switchflag ${switch}
+
+# is this important? or does it just need to be big enough?
+
+variable rcutneigh equal 2.0*${rcutfac}*${radelem}
+
+pair_style zero ${rcutneigh}
+pair_coeff * *
+
+# define output
+
+thermo_style	custom step temp ke pe vol c_bgrid[1][1]
+thermo_modify norm yes
+
+run 0

--- a/mala/descriptors/in.bgrid_kokkos.python
+++ b/mala/descriptors/in.bgrid_kokkos.python
@@ -23,7 +23,7 @@ variable 	radelem equal 0.5
 variable 	bzero equal 0
 variable 	quadratic equal 0
 
-compute bgrid all sna/grid grid ${ngridx} ${ngridy} ${ngridz} ${rcutfac} ${rfac0} ${twojmax} ${radelem} ${wj} rmin0 ${rmin0} bzeroflag ${bzero} quadraticflag ${quadratic} switchflag ${switch}
+compute bgrid all sna/grid/kk grid ${ngridx} ${ngridy} ${ngridz} ${rcutfac} ${rfac0} ${twojmax} ${radelem} ${wj} rmin0 ${rmin0} bzeroflag ${bzero} quadraticflag ${quadratic} switchflag ${switch}
 
 # is this important? or does it just need to be big enough?
 


### PR DESCRIPTION
This PR will close #399. Based on https://github.com/mala-project/lammps/pull/1, which implements the LAMMPS side of things, this PR essentially just tells MALA to use the correct LAMMPS parameters and input scripts to use the GPU (via Kokkos) when calculating descriptors. 

To-Dos:

- [ ] Get the Kokkos-LAMMPS version to work with MALA - currently the separately build executable works, but not the library (the `-k` flag is not recognized, plus I get a segfault)
- [ ] Document LAMMPS build with Kokkos+GPU
- [ ] Test results