### PR TITLE
openPMD: shuffle data in parallel

### DIFF
--- a/mala/common/physical_data.py
+++ b/mala/common/physical_data.py
@@ -338,6 +338,7 @@ class PhysicalData(ABC):
         ----------
         path : string
             File to save into. If no file ending is given, .h5 is assumed.
+            Alternatively: A Series, opened already.
 
         array : Either numpy.ndarray or an SkipArrayWriting object
             Either the array to save or the meta information needed to create
@@ -353,26 +354,30 @@ class PhysicalData(ABC):
         """
         import openpmd_api as io
 
-        file_name = os.path.basename(path)
-        file_ending = file_name.split(".")[-1]
-        if file_name == file_ending:
-            path += ".h5"
-        elif file_ending not in io.file_extensions:
-            raise Exception("Invalid file ending selected: " +
-                            file_ending)
-        if self.parameters._configuration["mpi"]:
-            series = io.Series(
-                path,
-                io.Access.create,
-                get_comm(),
-                options=json.dumps(
-                    self.parameters._configuration["openpmd_configuration"]))
-        else:
-            series = io.Series(
-                path,
-                io.Access.create,
-                options=json.dumps(
-                    self.parameters._configuration["openpmd_configuration"]))
+        if isinstance(path, str):
+            file_name = os.path.basename(path)
+            file_ending = file_name.split(".")[-1]
+            if file_name == file_ending:
+                path += ".h5"
+            elif file_ending not in io.file_extensions:
+                raise Exception("Invalid file ending selected: " +
+                                file_ending)
+            if self.parameters._configuration["mpi"]:
+                series = io.Series(
+                    path,
+                    io.Access.create,
+                    get_comm(),
+                    options=json.dumps(
+                        self.parameters._configuration["openpmd_configuration"]))
+            else:
+                series = io.Series(
+                    path,
+                    io.Access.create,
+                    options=json.dumps(
+                        self.parameters._configuration["openpmd_configuration"]))
+        elif isinstance(path, io.Series):
+            series = path
+
         series.set_attribute("is_mala_data", 1)
         series.set_software(name="MALA", version=mala_version)
         series.author = "..."

--- a/mala/common/physical_data.py
+++ b/mala/common/physical_data.py
@@ -242,7 +242,7 @@ class PhysicalData(ABC):
         loaded_array = np.load(path, mmap_mode="r")
         return self._process_loaded_dimensions(np.shape(loaded_array)), loaded_array.dtype
 
-    def read_dimensions_from_openpmd_file(self, path):
+    def read_dimensions_from_openpmd_file(self, path, comm=None):
         """
         Read only the dimensions from a openPMD file.
 
@@ -251,40 +251,50 @@ class PhysicalData(ABC):
         path : string
             Path to the openPMD file.
         """
-        import openpmd_api as io
-        # The union operator for dicts is only supported starting with
-        # python 3.9. Currently, MALA works down to python 3.8; For now,
-        # I think it is good to keep it that way.
-        # I will leave this code in for now, because that may change in the
-        # future.
-        # series = io.Series(path, io.Access.read_only,
-        #                    options=json.dumps(
-        #                         {"defer_iteration_parsing": True} |
-        #                         self.parameters.
-        #                             _configuration["openpmd_configuration"]))
-        options = self.parameters._configuration["openpmd_configuration"].copy()
-        options["defer_iteration_parsing"] = True
-        series = io.Series(path, io.Access.read_only,
-                           options=json.dumps(options))
+        if comm is None or comm.rank == 0:
+            import openpmd_api as io
+            # The union operator for dicts is only supported starting with
+            # python 3.9. Currently, MALA works down to python 3.8; For now,
+            # I think it is good to keep it that way.
+            # I will leave this code in for now, because that may change in the
+            # future.
+            # series = io.Series(path, io.Access.read_only,
+            #                    options=json.dumps(
+            #                         {"defer_iteration_parsing": True} |
+            #                         self.parameters.
+            #                             _configuration["openpmd_configuration"]))
+            options = self.parameters._configuration[
+                "openpmd_configuration"].copy()
+            options["defer_iteration_parsing"] = True
+            series = io.Series(path,
+                               io.Access.read_only,
+                               options=json.dumps(options))
 
-        # Check if this actually MALA compatible data.
-        if series.get_attribute("is_mala_data") != 1:
-            raise Exception("Non-MALA data detected, cannot work with this "
-                            "data.")
+            # Check if this actually MALA compatible data.
+            if series.get_attribute("is_mala_data") != 1:
+                raise Exception(
+                    "Non-MALA data detected, cannot work with this "
+                    "data.")
 
-        # A bit clanky, but this way only the FIRST iteration is loaded,
-        # which is what we need for loading from a single file that
-        # may be whatever iteration in its series.
-        # Also, in combination with `defer_iteration_parsing`, specified as
-        # default above, this opens and parses the first iteration,
-        # and no others.
-        for current_iteration in series.read_iterations():
-            mesh = current_iteration.meshes[self.data_name]
-            return self.\
-                _process_loaded_dimensions((mesh["0"].shape[0],
-                                            mesh["0"].shape[1],
-                                            mesh["0"].shape[2],
-                                            len(mesh)))
+            # A bit clanky, but this way only the FIRST iteration is loaded,
+            # which is what we need for loading from a single file that
+            # may be whatever iteration in its series.
+            # Also, in combination with `defer_iteration_parsing`, specified as
+            # default above, this opens and parses the first iteration,
+            # and no others.
+            for current_iteration in series.read_iterations():
+                mesh = current_iteration.meshes[self.data_name]
+                tuple_from_file = [mesh["0"].shape[0], mesh["0"].shape[1],
+                                   mesh["0"].shape[2], len(mesh)]
+                break
+            series.close()
+        else:
+            tuple_from_file = None
+
+        if comm is not None:
+            tuple_from_file = comm.bcast(tuple_from_file, root=0)
+
+        return self._process_loaded_dimensions(tuple(tuple_from_file))
 
     def write_to_numpy_file(self, path, array):
         """

--- a/mala/datahandling/data_handler_base.py
+++ b/mala/datahandling/data_handler_base.py
@@ -148,7 +148,7 @@ class DataHandlerBase(ABC):
     # Loading data
     ######################
 
-    def _check_snapshots(self):
+    def _check_snapshots(self, comm=None):
         """Check the snapshots for consistency."""
         self.nr_snapshots = len(self.parameters.snapshot_directories_list)
 
@@ -170,7 +170,7 @@ class DataHandlerBase(ABC):
                 tmp_dimension = self.descriptor_calculator. \
                     read_dimensions_from_openpmd_file(
                     os.path.join(snapshot.input_npy_directory,
-                                 snapshot.input_npy_file))
+                                 snapshot.input_npy_file), comm=comm)
             else:
                 raise Exception("Unknown snapshot file type.")
 
@@ -204,7 +204,7 @@ class DataHandlerBase(ABC):
                 tmp_dimension = self.target_calculator. \
                     read_dimensions_from_openpmd_file(
                     os.path.join(snapshot.output_npy_directory,
-                                 snapshot.output_npy_file))
+                                 snapshot.output_npy_file), comm=comm)
             else:
                 raise Exception("Unknown snapshot file type.")
 

--- a/mala/datahandling/data_shuffler.py
+++ b/mala/datahandling/data_shuffler.py
@@ -321,6 +321,8 @@ class DataShuffler(DataHandlerBase):
                     shuffle_dimensions)
             shuffled_snapshot_series.close()
 
+        # Ensure consistent parallel destruction
+        # Closing a series is a collective operation
         for series in input_series_list:
             series.close()
 

--- a/mala/datahandling/data_shuffler.py
+++ b/mala/datahandling/data_shuffler.py
@@ -8,6 +8,7 @@ from mala.common.parameters import ParametersData, Parameters, DEFAULT_NP_DATA_D
 from mala.common.parallelizer import printout
 from mala.common.physical_data import PhysicalData
 from mala.datahandling.data_handler_base import DataHandlerBase
+from mala.common.parallelizer import get_comm
 
 
 class DataShuffler(DataHandlerBase):
@@ -174,20 +175,40 @@ class DataShuffler(DataHandlerBase):
             self.name_infix = name_infix
             self.dimension = dimension
 
+    class __MockedMPIComm:
+
+        def __init__(self):
+            self.rank = 0
+            self.size = 1
+
 
     def __shuffle_openpmd(self, dot: __DescriptorOrTarget,
                           number_of_new_snapshots, shuffle_dimensions,
                           save_name, permutations, file_ending):
         import openpmd_api as io
+
+        if self.parameters._configuration["mpi"]:
+            comm = get_comm()
+        else:
+            comm = self.__MockedMPIComm()
+
         # Load the data
         input_series_list = []
         for idx, snapshot in enumerate(
                 self.parameters.snapshot_directories_list):
             # TODO: Use descriptor and target calculator for this.
-            input_series_list.append(
-                io.Series(
-                    os.path.join(dot.npy_directory(snapshot),
-                                 dot.npy_file(snapshot)), io.Access.read_only))
+            if isinstance(comm, self.__MockedMPIComm):
+                input_series_list.append(
+                    io.Series(
+                        os.path.join(dot.npy_directory(snapshot),
+                                     dot.npy_file(snapshot)),
+                        io.Access.read_only))
+            else:
+                input_series_list.append(
+                    io.Series(
+                        os.path.join(dot.npy_directory(snapshot),
+                                     dot.npy_file(snapshot)),
+                        io.Access.read_only, comm))
 
         # Peek into the input snapshots to determine the datatypes.
         for series in input_series_list:
@@ -221,21 +242,32 @@ class DataShuffler(DataHandlerBase):
             extent[slice_dimension] = single_chunk_len
             return offset, extent
 
+        import math
+        items_per_process = math.ceil(number_of_new_snapshots / comm.size)
+        my_items_start = comm.rank * items_per_process
+        my_items_end = min((comm.rank + 1) * items_per_process, number_of_new_snapshots)
+        my_items_count = my_items_end - my_items_start
+
+        import json
+
         # Do the actual shuffling.
-        # TODO: Parallelize into `number_of_new_snapshots` workers
-        # Each worker would write the i'th snapshot in serial, the input
-        # snapshots would be opened one after another in parallel
-        for i in range(0, number_of_new_snapshots):
+        for i in range(my_items_start, my_items_end):
             # We check above that in the non-numpy case, OpenPMD will work.
             dot.calculator.grid_dimensions = shuffle_dimensions
             name_prefix = os.path.join(dot.save_path,
                                        save_name.replace("*", str(i)))
-            shuffled_snapshot_series = dot.calculator.\
-                    write_to_openpmd_file(name_prefix+dot.name_infix+file_ending,
-                                          PhysicalData.SkipArrayWriting(dataset, feature_size),
-                                          additional_attributes={"global_shuffling_seed": self.parameters.shuffling_seed,
-                                                                 "local_shuffling_seed": i*self.parameters.shuffling_seed},
-                                          internal_iteration_number=i)
+            # do NOT open with MPI
+            shuffled_snapshot_series = io.Series(
+                name_prefix + dot.name_infix + file_ending,
+                io.Access.create,
+                options=json.dumps(
+                    self.parameters._configuration["openpmd_configuration"]))
+            dot.calculator.\
+                write_to_openpmd_file(shuffled_snapshot_series,
+                                        PhysicalData.SkipArrayWriting(dataset, feature_size),
+                                        additional_attributes={"global_shuffling_seed": self.parameters.shuffling_seed,
+                                                                "local_shuffling_seed": i*self.parameters.shuffling_seed},
+                                        internal_iteration_number=i)
             mesh_out = shuffled_snapshot_series.write_iterations()[i].meshes[
                 dot.calculator.data_name]
             new_array = np.zeros(
@@ -276,6 +308,9 @@ class DataShuffler(DataHandlerBase):
                 rc[:, :, :] = new_array[k, :][permutations[i]].reshape(
                     shuffle_dimensions)
             shuffled_snapshot_series.close()
+
+        for series in input_series_list:
+            series.close()
 
 
     def shuffle_snapshots(self,

--- a/mala/datahandling/data_shuffler.py
+++ b/mala/datahandling/data_shuffler.py
@@ -379,7 +379,7 @@ class DataShuffler(DataHandlerBase):
             file_ending = "npy"
 
         if self.parameters._configuration["mpi"]:
-            self._check_snapshots(comm=get_comm())
+            self._check_snapshots() #comm=get_comm())
         else:
             self._check_snapshots()
 

--- a/mala/datahandling/data_shuffler.py
+++ b/mala/datahandling/data_shuffler.py
@@ -378,9 +378,10 @@ class DataShuffler(DataHandlerBase):
         else:
             file_ending = "npy"
 
-        # TODO: This opens each input Series, change this for parallelization
-        # Check the dimensions of the snapshots.
-        self._check_snapshots()
+        if self.parameters._configuration["mpi"]:
+            self._check_snapshots(comm=get_comm())
+        else:
+            self._check_snapshots()
 
         snapshot_types = {
             snapshot.snapshot_type

--- a/mala/datahandling/data_shuffler.py
+++ b/mala/datahandling/data_shuffler.py
@@ -379,7 +379,7 @@ class DataShuffler(DataHandlerBase):
             file_ending = "npy"
 
         if self.parameters._configuration["mpi"]:
-            self._check_snapshots() #comm=get_comm())
+            self._check_snapshots(comm=get_comm())
         else:
             self._check_snapshots()
 


### PR DESCRIPTION
The data shuffling is relatively trivial to parallelize over the newly created shuffled checkpoints.
Processes cannot easily cooperate in the creation of one single checkpoint as the shuffling operation is global within one checkpoint.
So, this PR distributes the to-be-created checkpoints over parallel workers. The input checkpoints are accessed in parallel. This parallel access does not really scale to full system size, but since there is only ever a mediocre number of checkpoints, such scaling is not really necessary.
An alternative would be to access input checkpoints one after another in parallel, but this has performance impacts (checkpoints might be opened and closed multiple times if multiple shuffled checkpoints are created per process), and processes would have to ensure that each process opens the checkpoints exactly the same amount of time.
---> Easier to just open everything, since it's fine to do so anyway.