### PR TITLE
fixed indentation in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using these metadata."
 authors:
- - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
+  - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
     family-names: Cangi
     given-names: Attila
     orcid: https://orcid.org/0000-0001-9162-262X
@@ -10,7 +10,7 @@ authors:
     family-names: Rajamanickam
     given-names: Sivasankaran
     orcid: https://orcid.org/0000-0002-5854-409X
-- affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
+  - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
     family-names: Brzoza
     given-names: Bartosz
   - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"


### PR DESCRIPTION
I had problems decifering CITATION.cff with cffconvert. I discovered that the indentation was wrong for some of the field. This fixes this problem.