### PR TITLE
Add warning for lammps pre-processing

### DIFF
--- a/mala/descriptors/descriptor.py
+++ b/mala/descriptors/descriptor.py
@@ -526,7 +526,7 @@ class Descriptor(PhysicalData):
         """
         from lammps import lammps
 
-        printout("Warning: do not initialize more than one pre-processing calculation\
+        parallel_warn("Do not initialize more than one pre-processing calculation\
 in the same directory at the same time. Data may be over-written.")
 
         if self.parameters._configuration["mpi"] and \

--- a/mala/descriptors/descriptor.py
+++ b/mala/descriptors/descriptor.py
@@ -526,6 +526,9 @@ class Descriptor(PhysicalData):
         """
         from lammps import lammps
 
+        printout("Warning: do not initialize more than one pre-processing calculation\
+in the same directory at the same time. Data may be over-written.")
+
         if self.parameters._configuration["mpi"] and \
            self.parameters._configuration["gpu"]:
             raise Exception("LAMMPS can currently only work with multiple "


### PR DESCRIPTION
Warning for users when pre-processing SNAP with lammps.  This is a temporary workaround for issue #502 