### PR TITLE
Added parallel GPU inference

### DIFF
--- a/mala/descriptors/descriptor.py
+++ b/mala/descriptors/descriptor.py
@@ -705,23 +705,24 @@ class Descriptor(PhysicalData):
                         "switch"] = self.parameters.bispectrum_switchflag
 
         else:
+            size = 1
             lammps_dict["ngridx"] = nx
             lammps_dict["ngridy"] = ny
             lammps_dict["ngridz"] = nz
             lammps_dict[
                 "switch"] = self.parameters.bispectrum_switchflag
-            if self.parameters._configuration["gpu"]:
-                # Tell Kokkos to use one GPU.
-                lmp_cmdargs.append("-k")
-                lmp_cmdargs.append("on")
-                lmp_cmdargs.append("g")
-                lmp_cmdargs.append("1")
+        if self.parameters._configuration["gpu"]:
+            # Tell Kokkos to use one GPU.
+            lmp_cmdargs.append("-k")
+            lmp_cmdargs.append("on")
+            lmp_cmdargs.append("g")
+            lmp_cmdargs.append(str(size))
 
-                # Tell LAMMPS to use Kokkos versions of those commands for
-                # which a Kokkos version exists.
-                lmp_cmdargs.append("-sf")
-                lmp_cmdargs.append("kk")
-                pass
+            # Tell LAMMPS to use Kokkos versions of those commands for
+            # which a Kokkos version exists.
+            lmp_cmdargs.append("-sf")
+            lmp_cmdargs.append("kk")
+            pass
 
         lmp_cmdargs = set_cmdlinevars(lmp_cmdargs, lammps_dict)
 

--- a/mala/descriptors/descriptor.py
+++ b/mala/descriptors/descriptor.py
@@ -526,12 +526,6 @@ class Descriptor(PhysicalData):
         """
         from lammps import lammps
 
-        if self.parameters._configuration["mpi"] and \
-           self.parameters._configuration["gpu"]:
-            raise Exception("LAMMPS can currently only work with multiple "
-                            "ranks or GPU on one rank - but not multiple GPUs "
-                            "across ranks.")
-
         # Build LAMMPS arguments from the data we read.
         lmp_cmdargs = ["-screen", "none", "-log",
                        os.path.join(outdir, log_file_name)]

--- a/mala/network/network.py
+++ b/mala/network/network.py
@@ -190,12 +190,8 @@ class Network(nn.Module):
             The network that was loaded from the file.
         """
         loaded_network = Network(params)
-        if params.use_gpu:
-            loaded_network.load_state_dict(torch.load(file,
-                                                      map_location=params.device))
-        else:
-            loaded_network.load_state_dict(torch.load(file,
-                                                      map_location="cpu"))
+        loaded_network.\
+            load_state_dict(torch.load(file, map_location=params.device))
         loaded_network.eval()
         return loaded_network
 

--- a/mala/network/network.py
+++ b/mala/network/network.py
@@ -192,7 +192,7 @@ class Network(nn.Module):
         loaded_network = Network(params)
         if params.use_gpu:
             loaded_network.load_state_dict(torch.load(file,
-                                                      map_location="cuda"))
+                                                      map_location=params.device))
         else:
             loaded_network.load_state_dict(torch.load(file,
                                                       map_location="cpu"))

--- a/mala/network/predictor.py
+++ b/mala/network/predictor.py
@@ -187,6 +187,11 @@ class Predictor(Runner):
     def _forward_snap_descriptors(self, snap_descriptors,
                                   local_data_size=None):
         """Forward a scaled tensor of descriptors through the NN."""
+        # Ensure the Network is on the correct device.
+        # This line is necessary because GPU acceleration may have been
+        # activated AFTER loading a model.
+        self.network.to(self.network.params._configuration["device"])
+
         if local_data_size is None:
             local_data_size = self.data.grid_size
         predicted_outputs = \

--- a/mala/network/runner.py
+++ b/mala/network/runner.py
@@ -114,7 +114,8 @@ class Runner:
     @classmethod
     def load_run(cls, run_name, path="./", zip_run=True,
                  params_format="json", load_runner=True,
-                 prepare_data=False, load_with_mpi=False):
+                 prepare_data=False, load_with_mpi=None,
+                 load_with_gpu=None):
         """
         Load a run.
 
@@ -142,12 +143,21 @@ class Runner:
             continuing a model training.
 
         load_with_mpi : bool
-            If False (default) no additional MPI will be activated during
-            loading. If True, MPI will be activated during loading.
-            MPI usage has to be enabled upon loading, since neural network
-            parameters have to be loaded onto the correct GPU.
-            If MPI was already enabled at the end of the training loop,
-            this parameter will have no effect.
+            Can be used to actively enable/disable MPI during loading.
+            Default is None, so that the MPI parameters set during
+            training/saving of the model are not overwritten.
+            If MPI is to be used in concert with GPU during training,
+            MPI already has to be activated here, if it was not activated
+            during training!
+
+        load_with_gpu : bool
+            Can be used to actively enable/disable GPU during loading.
+            Default is None, so that the GPU parameters set during
+            training/saving of the model are not overwritten.
+            If MPI is to be used in concert with GPU during training,
+            it is advised that GPU usage is activated here, if it was not
+            activated during training. Can also be used to activate a CPU
+            based inference, by setting it to False.
 
         Return
         ------
@@ -193,8 +203,11 @@ class Runner:
         loaded_params = Parameters.load_from_json(loaded_params)
 
         # MPI has to be specified upon loading, in contrast to GPU.
-        if load_with_mpi is True:
+        if load_with_mpi is not None:
             loaded_params.use_mpi = load_with_mpi
+        if load_with_gpu is not None:
+            loaded_params.use_gpu = load_with_gpu
+
         loaded_network = Network.load_from_file(loaded_params,
                                                 loaded_network)
         loaded_iscaler = DataScaler.load_from_file(loaded_iscaler)

--- a/mala/network/runner.py
+++ b/mala/network/runner.py
@@ -114,7 +114,7 @@ class Runner:
     @classmethod
     def load_run(cls, run_name, path="./", zip_run=True,
                  params_format="json", load_runner=True,
-                 prepare_data=False, use_mpi=None):
+                 prepare_data=False, load_with_mpi=False):
         """
         Load a run.
 
@@ -140,6 +140,14 @@ class Runner:
         prepare_data : bool
             If True, the data will be loaded into memory. This is needed when
             continuing a model training.
+
+        load_with_mpi : bool
+            If False (default) no additional MPI will be activated during
+            loading. If True, MPI will be activated during loading.
+            MPI usage has to be enabled upon loading, since neural network
+            parameters have to be loaded onto the correct GPU.
+            If MPI was already enabled at the end of the training loop,
+            this parameter will have no effect.
 
         Return
         ------
@@ -183,8 +191,10 @@ class Runner:
                                          ".params."+params_format)
 
         loaded_params = Parameters.load_from_json(loaded_params)
-        if use_mpi is not None:
-            loaded_params.use_mpi = use_mpi
+
+        # MPI has to be specified upon loading, in contrast to GPU.
+        if load_with_mpi is True:
+            loaded_params.use_mpi = load_with_mpi
         loaded_network = Network.load_from_file(loaded_params,
                                                 loaded_network)
         loaded_iscaler = DataScaler.load_from_file(loaded_iscaler)

--- a/mala/network/runner.py
+++ b/mala/network/runner.py
@@ -295,6 +295,11 @@ class Runner:
         predicted_outputs : numpy.ndarray
             Precicted outputs for snapshot.
         """
+        # Ensure the Network is on the correct device.
+        # This line is necessary because GPU acceleration may have been
+        # activated AFTER loading a model.
+        self.network.to(self.network.params._configuration["device"])
+
         # Determine where the snapshot begins and ends.
         from_index = 0
         to_index = None

--- a/mala/network/runner.py
+++ b/mala/network/runner.py
@@ -114,7 +114,7 @@ class Runner:
     @classmethod
     def load_run(cls, run_name, path="./", zip_run=True,
                  params_format="json", load_runner=True,
-                 prepare_data=False):
+                 prepare_data=False, use_mpi=None):
         """
         Load a run.
 
@@ -183,6 +183,8 @@ class Runner:
                                          ".params."+params_format)
 
         loaded_params = Parameters.load_from_json(loaded_params)
+        if use_mpi is not None:
+            loaded_params.use_mpi = use_mpi
         loaded_network = Network.load_from_file(loaded_params,
                                                 loaded_network)
         loaded_iscaler = DataScaler.load_from_file(loaded_iscaler)

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -1046,10 +1046,21 @@ class Density(Target):
             t0 = time.perf_counter()
             gaussian_descriptors = \
                 np.reshape(gaussian_descriptors,
-                           [number_of_gridpoints, 1], order='F')
+                           [number_of_gridpoints_mala, 1], order='F')
             reference_gaussian_descriptors = \
                 np.reshape(reference_gaussian_descriptors,
-                           [number_of_gridpoints, 1], order='F')
+                           [number_of_gridpoints_mala, 1], order='F')
+
+            # If there is an inconsistency between MALA and QE (which
+            # can only happen in the uneven z-splitting case at the moment)
+            # we need to pad the gaussian descriptor arrays.
+            if number_of_gridpoints_mala < number_of_gridpoints:
+                grid_diff = number_of_gridpoints - number_of_gridpoints_mala
+                gaussian_descriptors = np.pad(gaussian_descriptors,
+                                            pad_width=((0, grid_diff), (0, 0)))
+                reference_gaussian_descriptors = np.pad(reference_gaussian_descriptors,
+                                            pad_width=((0, grid_diff), (0, 0)))
+
             sigma = self._parameters_full.descriptors.\
                 atomic_density_sigma
             sigma = sigma / Bohr


### PR DESCRIPTION
This PR, together with @rohskopf changes made to LAMMPS (https://github.com/mala-project/lammps/pull/3) allows for MALA inferences using multiple GPUs. Bispectrum descriptor calculation, network inference, Gaussian descriptor calculation and observable calculation will be parallelized across multiple ranks. Each rank has a GPU attached to it. 

Accuracy has been confirmed for cubic systems (Al cells with 256 and 1024 atoms) and hexagonal systems (beryllium with up to 131072). Scaling behavior is linear. 
I am not posting results here right away because they may be used in the upcoming MALA technical paper. 