### PR TITLE
Remove hardcoded iteration number from data shuffler

### DIFF
--- a/mala/common/physical_data.py
+++ b/mala/common/physical_data.py
@@ -418,7 +418,8 @@ class PhysicalData(ABC):
         import openpmd_api as io
 
         if isinstance(path, str):
-            file_name = os.path.basename(path)
+            directory, file_name = os.path.split(path)
+            path = os.path.join(directory, file_name.replace("*", "%T"))
             file_ending = file_name.split(".")[-1]
             if file_name == file_ending:
                 path += ".h5"

--- a/mala/common/physical_data.py
+++ b/mala/common/physical_data.py
@@ -419,7 +419,7 @@ class PhysicalData(ABC):
 
         if isinstance(path, str):
             directory, file_name = os.path.split(path)
-            path = os.path.join(directory, file_name.replace("*", "%T"))
+            path = os.path.join(directory, file_name.replace("*", "%06T"))
             file_ending = file_name.split(".")[-1]
             if file_name == file_ending:
                 path += ".h5"

--- a/mala/common/physical_data.py
+++ b/mala/common/physical_data.py
@@ -419,7 +419,7 @@ class PhysicalData(ABC):
 
         if isinstance(path, str):
             directory, file_name = os.path.split(path)
-            path = os.path.join(directory, file_name.replace("*", "%06T"))
+            path = os.path.join(directory, file_name.replace("*", "%T"))
             file_ending = file_name.split(".")[-1]
             if file_name == file_ending:
                 path += ".h5"

--- a/mala/datahandling/data_shuffler.py
+++ b/mala/datahandling/data_shuffler.py
@@ -132,9 +132,9 @@ class DataShuffler(DataHandlerBase):
 
         # Do the actual shuffling.
         target_name_openpmd = os.path.join(target_save_path,
-                                       save_name.replace("*", "%T"))
+                                       save_name.replace("*", "%06T"))
         descriptor_name_openpmd = os.path.join(descriptor_save_path,
-                                        save_name.replace("*", "%T"))
+                                        save_name.replace("*", "%06T"))
         for i in range(0, number_of_new_snapshots):
             new_descriptors = np.zeros(
                 (int(np.prod(shuffle_dimensions)), self.input_dimension),
@@ -364,7 +364,7 @@ class DataShuffler(DataHandlerBase):
 
         # Do the actual shuffling.
         name_prefix = os.path.join(
-            dot.save_path, save_name.replace("*", "%T")
+            dot.save_path, save_name.replace("*", "%06T")
         )
         for i in range(my_items_start, my_items_end):
             # We check above that in the non-numpy case, OpenPMD will work.

--- a/mala/datahandling/data_shuffler.py
+++ b/mala/datahandling/data_shuffler.py
@@ -132,9 +132,9 @@ class DataShuffler(DataHandlerBase):
 
         # Do the actual shuffling.
         target_name_openpmd = os.path.join(target_save_path,
-                                       save_name.replace("*", "%06T"))
+                                       save_name.replace("*", "%T"))
         descriptor_name_openpmd = os.path.join(descriptor_save_path,
-                                        save_name.replace("*", "%06T"))
+                                        save_name.replace("*", "%T"))
         for i in range(0, number_of_new_snapshots):
             new_descriptors = np.zeros(
                 (int(np.prod(shuffle_dimensions)), self.input_dimension),
@@ -364,7 +364,7 @@ class DataShuffler(DataHandlerBase):
 
         # Do the actual shuffling.
         name_prefix = os.path.join(
-            dot.save_path, save_name.replace("*", "%06T")
+            dot.save_path, save_name.replace("*", "%T")
         )
         for i in range(my_items_start, my_items_end):
             # We check above that in the non-numpy case, OpenPMD will work.

--- a/mala/datahandling/data_shuffler.py
+++ b/mala/datahandling/data_shuffler.py
@@ -131,6 +131,10 @@ class DataShuffler(DataHandlerBase):
             )
 
         # Do the actual shuffling.
+        target_name_openpmd = os.path.join(target_save_path,
+                                       save_name.replace("*", "%T"))
+        descriptor_name_openpmd = os.path.join(descriptor_save_path,
+                                        save_name.replace("*", "%T"))
         for i in range(0, number_of_new_snapshots):
             new_descriptors = np.zeros(
                 (int(np.prod(shuffle_dimensions)), self.input_dimension),
@@ -209,7 +213,7 @@ class DataShuffler(DataHandlerBase):
                     shuffle_dimensions
                 )
                 self.descriptor_calculator.write_to_openpmd_file(
-                    descriptor_name + ".in." + file_ending,
+                    descriptor_name_openpmd + ".in." + file_ending,
                     new_descriptors,
                     additional_attributes={
                         "global_shuffling_seed": self.parameters.shuffling_seed,
@@ -219,7 +223,7 @@ class DataShuffler(DataHandlerBase):
                     internal_iteration_number=i,
                 )
                 self.target_calculator.write_to_openpmd_file(
-                    target_name + ".out." + file_ending,
+                    target_name_openpmd + ".out." + file_ending,
                     array=new_targets,
                     additional_attributes={
                         "global_shuffling_seed": self.parameters.shuffling_seed,
@@ -359,12 +363,12 @@ class DataShuffler(DataHandlerBase):
         import json
 
         # Do the actual shuffling.
+        name_prefix = os.path.join(
+            dot.save_path, save_name.replace("*", "%T")
+        )
         for i in range(my_items_start, my_items_end):
             # We check above that in the non-numpy case, OpenPMD will work.
             dot.calculator.grid_dimensions = list(shuffle_dimensions)
-            name_prefix = os.path.join(
-                dot.save_path, save_name.replace("*", str(i))
-            )
             # do NOT open with MPI
             shuffled_snapshot_series = io.Series(
                 name_prefix + dot.name_infix + file_ending,


### PR DESCRIPTION
Until now, the DataShuffler replaces the `*` pattern with the snapshot number before passing the file name to openPMD. It's better to set `%T` here so openPMD knows the structure of the filename. With this fix, the output data can be accessed as one data series with openPMD tooling, e.g.
```
> openpmd-ls Be_shuffled%T.in.h5
openPMD series: Be_shuffled%T.in
openPMD standard: 1.1.0
openPMD extensions: 0

data author: ...
data created: 2024-03-11 11:31:55 +0100
data backend: HDF5
generating machine: unknown
generating software: MALA (version: 1.2.1)
generating software dependencies: unknown

number of iterations: 2 (fileBased)
  all iterations: 0 1 

number of meshes: 1
  all meshes:
    Bispectrum

number of particle species: 0
franzpoeschel:~/git-repos/mala/examples/advanced
> openpmd-ls Be_shuffled%T.out.h5
openPMD series: Be_shuffled%T.out
openPMD standard: 1.1.0
openPMD extensions: 0

data author: ...
data created: 2024-03-11 11:31:55 +0100
data backend: HDF5
generating machine: unknown
generating software: MALA (version: 1.2.1)
generating software dependencies: unknown

number of iterations: 2 (fileBased)
  all iterations: 0 1 

number of meshes: 1
  all meshes:
    LDOS

number of particle species: 0
```