### PR TITLE
Add `pre-commit` config, format remaining files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# https://black.readthedocs.io/en/stable/integrations/source_version_control.html
+
+repos:
+  # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.4.0
+    hooks:
+      - id: black
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3.12

--- a/docs/source/CONTRIBUTE.md
+++ b/docs/source/CONTRIBUTE.md
@@ -93,10 +93,19 @@ the core development team.
 ### Formatting code
 
 * MALA uses [`black`](https://github.com/psf/black) for code formatting
-* The `black` configuration is located in `pyproject.toml`
+* The `black` configuration is located in `pyproject.toml`, the `black` version
+  is specified in `.pre-commit-config.yaml`
 * Currently, no automatic code reformatting will be done in the CI, thus
-  please ensure that your code is properly formatted before creating a pull 
-  request
+  please ensure that your code is properly formatted before creating a pull
+  request. We suggest to use [`pre-commit`](https://pre-commit.com/). You can
+
+  * manually run `pre-commit run -a` at any given time
+  * configure it to run before each commit by executing `pre-commit install`
+    once locally
+
+  Without `pre-commit`, please install the `black` version named in
+  `.pre-commit-config.yaml` and run `find -name "*.py" | xargs black` or just
+  `black my_modified_file.py`.
 
 ### Adding dependencies
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,25 +13,31 @@
 import os
 import subprocess
 import sys
+
 # sys.path.insert(0, os.path.abspath('.'))
-sys.path.insert(0, os.path.abspath('../../'))
+sys.path.insert(0, os.path.abspath("../../"))
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'Materials Learning Algorithms (MALA)'
-copyright = '2021 National Technology & Engineering Solutions of Sandia, ' \
-            'LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, ' \
-            'the U.S. Government retains certain rights in this software. ' \
-            'Attila Cangi, J. Austin Ellis, Lenz Fiedler, Daniel Kotik, ' \
-            'Normand Modine, Sivasankaran Rajamanickam, Steve Schmerler, Aidan Thompson'
+project = "Materials Learning Algorithms (MALA)"
+copyright = (
+    "2021 National Technology & Engineering Solutions of Sandia, "
+    "LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, "
+    "the U.S. Government retains certain rights in this software. "
+    "Attila Cangi, J. Austin Ellis, Lenz Fiedler, Daniel Kotik, "
+    "Normand Modine, Sivasankaran Rajamanickam, Steve Schmerler, Aidan Thompson"
+)
 
-author = 'Attila Cangi, J. Austin Ellis, Lenz Fiedler, Daniel Kotik, ' \
-         'Normand Modine, Sivasankaran Rajamanickam, Steve Schmerler, Aidan Thompson'
+author = (
+    "Attila Cangi, J. Austin Ellis, Lenz Fiedler, Daniel Kotik, "
+    "Normand Modine, Sivasankaran Rajamanickam, Steve Schmerler, Aidan Thompson"
+)
 
 # The version info for the project
-tag = subprocess.run(['git', 'describe', '--tags'], capture_output=True,
-                        text=True)
+tag = subprocess.run(
+    ["git", "describe", "--tags"], capture_output=True, text=True
+)
 version = tag.stdout.strip()
 
 
@@ -41,47 +47,47 @@ version = tag.stdout.strip()
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'myst_parser',
-    'sphinx_markdown_tables',
-    'sphinx_copybutton',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.coverage',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages',
+    "myst_parser",
+    "sphinx_markdown_tables",
+    "sphinx_copybutton",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.coverage",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.githubpages",
 ]
 
 napoleon_google_docstring = False
 napoleon_numpy_docstring = True
 
 autodoc_mock_imports = [
-    'ase',
-    'optuna',
-    'mpmath',
-    'torch',
-    'numpy',
-    'scipy',
-    'oapackage',
-    'matplotlib',
-    'horovod',
-    'lammps',
-    'total_energy',
-    'pqkmeans',
-    'dftpy',
-    'asap3',
-    'openpmd_io',
-    'skspatial'
+    "ase",
+    "optuna",
+    "mpmath",
+    "torch",
+    "numpy",
+    "scipy",
+    "oapackage",
+    "matplotlib",
+    "horovod",
+    "lammps",
+    "total_energy",
+    "pqkmeans",
+    "dftpy",
+    "asap3",
+    "openpmd_io",
+    "skspatial",
 ]
 
 myst_heading_anchors = 3
 
-autodoc_member_order = 'groupwise'
+autodoc_member_order = "groupwise"
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['templates']
+templates_path = ["templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -94,7 +100,7 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -102,22 +108,22 @@ html_theme = 'sphinx_rtd_theme'
 html_logo = "./img/logos/mala_horizontal_white.png"
 
 html_context = {
-  'display_github': True,
-  'github_repo': 'mala-project/mala',
-  'github_version': 'develop',
-  'conf_py_path': '/docs/source/',
+    "display_github": True,
+    "github_repo": "mala-project/mala",
+    "github_version": "develop",
+    "conf_py_path": "/docs/source/",
 }
 
 html_theme_options = {
-    'logo_only': True,
-    'display_version': False,
+    "logo_only": True,
+    "display_version": False,
 }
-html_static_path = ['_static']
+html_static_path = ["_static"]
 # html_static_path = []
 html_css_files = ["css/custom.css"]
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = "./img/logos/mala_vertical.png"
+# html_logo = "./img/logos/mala_vertical.png"
 
 # The name of an image file (relative to this directory) to use as a favicon of
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
@@ -126,12 +132,9 @@ html_favicon = "./img/logos/mala_favicon.png"
 
 # The suffix of source file names.
 source_suffix = {
-    '.rst': 'restructuredtext',
-    '.txt': 'markdown',
-    '.md': 'markdown',
+    ".rst": "restructuredtext",
+    ".txt": "markdown",
+    ".md": "markdown",
 }
 
 add_module_names = False
-
-
-

--- a/setup.py
+++ b/setup.py
@@ -15,27 +15,30 @@ with open("LICENSE") as f:
     license = f.read()
 
 extras = {
-    'dev': ['bump2version'],
-    'opt': ['oapackage'],
-    'test': ['pytest'],
-    'doc': open('docs/requirements.txt').read().splitlines(),
-    'experimental': ['asap3', 'dftpy', 'minterpy']
+    "dev": ["bump2version"],
+    "opt": ["oapackage"],
+    "test": ["pytest"],
+    "doc": open("docs/requirements.txt").read().splitlines(),
+    "experimental": ["asap3", "dftpy", "minterpy"],
 }
 
 setup(
     name="materials-learning-algorithms",
     version=version["__version__"],
-    description=("Materials Learning Algorithms. "
-                 "A framework for machine learning materials properties from "
-                 "first-principles data."),
+    description=(
+        "Materials Learning Algorithms. "
+        "A framework for machine learning materials properties from "
+        "first-principles data."
+    ),
     long_description=readme,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     url="https://github.com/mala-project/mala",
     author="MALA developers",
     license=license,
-    packages=find_packages(exclude=("test", "docs", "examples", "install",
-                                    "ml-dft-sandia")),
+    packages=find_packages(
+        exclude=("test", "docs", "examples", "install", "ml-dft-sandia")
+    ),
     zip_safe=False,
-    install_requires=open('requirements.txt').read().splitlines(),
+    install_requires=open("requirements.txt").read().splitlines(),
     extras_require=extras,
 )


### PR DESCRIPTION
As suggested in #501, this adds `.pre-commit-config.yaml` to help `black` adoption. 

This doesn't enforce anything. If people don't use `pre-commit` locally, this has no effect. It however defines the `black` version and thus the formatting rules that the project wishes to see applied.

This PR also formats `setup.py` and `docs/source/conf.py`.