### PR TITLE
Timestamping LAMMPS temporary files

### DIFF
--- a/mala/descriptors/atomic_density.py
+++ b/mala/descriptors/atomic_density.py
@@ -134,9 +134,12 @@ class AtomicDensity(Descriptor):
 
         use_fp64 = kwargs.get("use_fp64", False)
         return_directly = kwargs.get("return_directly", False)
+        keep_logs = kwargs.get("keep_logs", False)
 
         lammps_format = "lammps-data"
-        ase_out_path = os.path.join(outdir, "lammps_input.tmp")
+        ase_out_path = os.path.join(
+            outdir, "lammps_input_" + self.calculation_timestamp + ".tmp"
+        )
         ase.io.write(ase_out_path, self.atoms, format=lammps_format)
 
         nx = self.grid_dimensions[0]
@@ -155,14 +158,11 @@ class AtomicDensity(Descriptor):
         lammps_dict["sigma"] = self.parameters.atomic_density_sigma
         lammps_dict["rcutfac"] = self.parameters.atomic_density_cutoff
         lammps_dict["atom_config_fname"] = ase_out_path
-        lmp = self._setup_lammps(
-            nx,
-            ny,
-            nz,
+        log_path = os.path.join(
             outdir,
-            lammps_dict,
-            log_file_name="lammps_ggrid_log.tmp",
+            "lammps_ggrid_log_" + self.calculation_timestamp + ".tmp",
         )
+        lmp = self._setup_lammps(nx, ny, nz, lammps_dict, log_path)
 
         # For now the file is chosen automatically, because this is used
         # mostly under the hood anyway.
@@ -175,6 +175,10 @@ class AtomicDensity(Descriptor):
         else:
             runfile = os.path.join(filepath, "in.ggrid_defaultproc.python")
         lmp.file(runfile)
+
+        if not keep_logs:
+            os.remove(ase_out_path)
+            os.remove(log_path)
 
         # Extract the data.
         nrows_ggrid = extract_compute_np(

--- a/mala/descriptors/atomic_density.py
+++ b/mala/descriptors/atomic_density.py
@@ -185,7 +185,6 @@ class AtomicDensity(Descriptor):
 
         # Do the LAMMPS calculation and clean up.
         lmp.file(self.parameters.lammps_compute_file)
-        self._clean_calculation(keep_logs)
 
         # Extract the data.
         nrows_ggrid = extract_compute_np(
@@ -209,7 +208,7 @@ class AtomicDensity(Descriptor):
             array_shape=(nrows_ggrid, ncols_ggrid),
             use_fp64=use_fp64,
         )
-        lmp.close()
+        self._clean_calculation(lmp, keep_logs)
 
         # In comparison to SNAP, the atomic density always returns
         # in the "local mode". Thus we have to make some slight adjustments

--- a/mala/descriptors/atomic_density.py
+++ b/mala/descriptors/atomic_density.py
@@ -137,10 +137,12 @@ class AtomicDensity(Descriptor):
         keep_logs = kwargs.get("keep_logs", False)
 
         lammps_format = "lammps-data"
-        ase_out_path = os.path.join(
+        self.lammps_temporary_input = os.path.join(
             outdir, "lammps_input_" + self.calculation_timestamp + ".tmp"
         )
-        ase.io.write(ase_out_path, self.atoms, format=lammps_format)
+        ase.io.write(
+            self.lammps_temporary_input, self.atoms, format=lammps_format
+        )
 
         nx = self.grid_dimensions[0]
         ny = self.grid_dimensions[1]
@@ -154,15 +156,15 @@ class AtomicDensity(Descriptor):
             )
 
         # Create LAMMPS instance.
-        lammps_dict = {}
-        lammps_dict["sigma"] = self.parameters.atomic_density_sigma
-        lammps_dict["rcutfac"] = self.parameters.atomic_density_cutoff
-        lammps_dict["atom_config_fname"] = ase_out_path
-        log_path = os.path.join(
+        lammps_dict = {
+            "sigma": self.parameters.atomic_density_sigma,
+            "rcutfac": self.parameters.atomic_density_cutoff,
+        }
+        self.lammps_temporary_log = os.path.join(
             outdir,
             "lammps_ggrid_log_" + self.calculation_timestamp + ".tmp",
         )
-        lmp = self._setup_lammps(nx, ny, nz, lammps_dict, log_path)
+        lmp = self._setup_lammps(nx, ny, nz, lammps_dict)
 
         # For now the file is chosen automatically, because this is used
         # mostly under the hood anyway.
@@ -174,11 +176,10 @@ class AtomicDensity(Descriptor):
                 runfile = os.path.join(filepath, "in.ggrid_defaultproc.python")
         else:
             runfile = os.path.join(filepath, "in.ggrid_defaultproc.python")
-        lmp.file(runfile)
 
-        if not keep_logs:
-            os.remove(ase_out_path)
-            os.remove(log_path)
+        # Do the LAMMPS calculation and clean up.
+        lmp.file(self.parameters.lammps_compute_file)
+        self._clean_calculation(keep_logs)
 
         # Extract the data.
         nrows_ggrid = extract_compute_np(

--- a/mala/descriptors/atomic_density.py
+++ b/mala/descriptors/atomic_density.py
@@ -171,11 +171,17 @@ class AtomicDensity(Descriptor):
         filepath = __file__.split("atomic_density")[0]
         if self.parameters._configuration["mpi"]:
             if self.parameters.use_z_splitting:
-                runfile = os.path.join(filepath, "in.ggrid.python")
+                self.parameters.lammps_compute_file = os.path.join(
+                    filepath, "in.ggrid.python"
+                )
             else:
-                runfile = os.path.join(filepath, "in.ggrid_defaultproc.python")
+                self.parameters.lammps_compute_file = os.path.join(
+                    filepath, "in.ggrid_defaultproc.python"
+                )
         else:
-            runfile = os.path.join(filepath, "in.ggrid_defaultproc.python")
+            self.parameters.lammps_compute_file = os.path.join(
+                filepath, "in.ggrid_defaultproc.python"
+            )
 
         # Do the LAMMPS calculation and clean up.
         lmp.file(self.parameters.lammps_compute_file)

--- a/mala/descriptors/bispectrum.py
+++ b/mala/descriptors/bispectrum.py
@@ -184,7 +184,6 @@ class Bispectrum(Descriptor):
 
         # Do the LAMMPS calculation and clean up.
         lmp.file(self.parameters.lammps_compute_file)
-        self._clean_calculation(keep_logs)
 
         # Set things not accessible from LAMMPS
         # First 3 cols are x, y, z, coords
@@ -228,7 +227,7 @@ class Bispectrum(Descriptor):
                 array_shape=(nrows_local, ncols_local),
                 use_fp64=use_fp64,
             )
-            lmp.close()
+            self._clean_calculation(lmp, keep_logs)
 
             # Copy the grid dimensions only at the end.
             self.grid_dimensions = [nx, ny, nz]
@@ -244,7 +243,7 @@ class Bispectrum(Descriptor):
                 (nz, ny, nx, self.fingerprint_length),
                 use_fp64=use_fp64,
             )
-            lmp.close()
+            self._clean_calculation(lmp, keep_logs)
 
             # switch from x-fastest to z-fastest order (swaps 0th and 2nd
             # dimension)

--- a/mala/descriptors/descriptor.py
+++ b/mala/descriptors/descriptor.py
@@ -820,7 +820,8 @@ class Descriptor(PhysicalData):
 
         return lmp
 
-    def _clean_calculation(self, keep_logs):
+    def _clean_calculation(self, lmp, keep_logs):
+        lmp.close()
         if not keep_logs:
             if get_rank() == 0:
                 os.remove(self.lammps_temporary_log)

--- a/mala/descriptors/minterpy_descriptors.py
+++ b/mala/descriptors/minterpy_descriptors.py
@@ -193,7 +193,9 @@ class MinterpyDescriptors(Descriptor):
                 # else:
                 #     runfile = os.path.join(filepath, "in.ggrid_defaultproc.python")
             else:
-                runfile = os.path.join(filepath, "in.ggrid_defaultproc.python")
+                self.parameters.lammps_compute_file = os.path.join(
+                    filepath, "in.ggrid_defaultproc.python"
+                )
 
             # Do the LAMMPS calculation and clean up.
             lmp.file(self.parameters.lammps_compute_file)

--- a/mala/descriptors/minterpy_descriptors.py
+++ b/mala/descriptors/minterpy_descriptors.py
@@ -171,14 +171,15 @@ class MinterpyDescriptors(Descriptor):
             )
 
             # Create LAMMPS instance.
-            lammps_dict = {}
-            lammps_dict["sigma"] = self.parameters.atomic_density_sigma
-            lammps_dict["rcutfac"] = self.parameters.atomic_density_cutoff
+            lammps_dict = {
+                "sigma": self.parameters.atomic_density_sigma,
+                "rcutfac": self.parameters.atomic_density_cutoff,
+            }
             self.lammps_temporary_log = os.path.join(
                 outdir,
                 "lammps_bgrid_log_" + self.calculation_timestamp + ".tmp",
             )
-            lmp = self._setup_lammps(nx, ny, nz, lammps_dict, log_path)
+            lmp = self._setup_lammps(nx, ny, nz, lammps_dict)
 
             # For now the file is chosen automatically, because this is used
             # mostly under the hood anyway.
@@ -199,7 +200,6 @@ class MinterpyDescriptors(Descriptor):
 
             # Do the LAMMPS calculation and clean up.
             lmp.file(self.parameters.lammps_compute_file)
-            self._clean_calculation(keep_logs)
 
             # Extract the data.
             nrows_ggrid = extract_compute_np(
@@ -223,7 +223,7 @@ class MinterpyDescriptors(Descriptor):
                 array_shape=(nrows_ggrid, ncols_ggrid),
             )
 
-            lmp.close()
+            self._clean_calculation(lmp, keep_logs)
 
             gaussian_descriptors_np = gaussian_descriptors_np.reshape(
                 (

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -649,7 +649,7 @@ class Target(PhysicalData):
     @abstractmethod
     def invalidate_target(self):
         """
-        Invalidates the saved target wuantity.
+        Invalidates the saved target quantity.
 
         This is the generic interface for cached target quantities.
         It should work for all implemented targets.


### PR DESCRIPTION
This PR adds a timestamp functionality to the creation of all temporary files for LAMMPS based descriptor calculations. This solves the issue documented in #502. 
Also implements automatic cleanup of temporary files by default (may be disabled by user if temporary files are needed for, e.g., debugging). 