### PR TITLE
Add workflow to delete untagged containers

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,15 @@
+name: Delete Untagged Container Versions
+
+on:
+  workflow_dispatch:
+
+jobs:
+  delete-untagged-containers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: mala_conda_cpu
+      - uses: actions/delete-package-versions@v5
+        with:
+          package_name: 'mala_conda_cpu'
+          package_type: 'container'
+          delete-only-untagged-versions: 'true'


### PR DESCRIPTION
This workflow removes (old) untagged `mala_conda_cpu` containers from the package registry. It can only be triggered manually, see https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow.

Closes #516