### PR TITLE
Update docs workflow and dependencies

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -36,12 +36,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # 0 fetches complete history and tags
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: docs
+name: Documenation
 
 on:
   pull_request:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test-docstrings:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.12'
 
       - name: Upgrade pip
         run: python3 -m pip install --upgrade pip
@@ -33,7 +33,7 @@ jobs:
 
   build-and-deploy-pages:
     needs: test-docstrings
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.12'
 
       - name: Upgrade pip
         run: python3 -m pip install --upgrade pip

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
-docutils==0.16
-Sphinx==4.5.*
-sphinx-rtd-theme==1.0.0
-myst-parser==0.17.2
+docutils==0.20.1
+Sphinx==7.3.7
+sphinx-rtd-theme==2.0.0
+myst-parser==3.0.1
 sphinx-markdown-tables==0.0.17
-sphinx-copybutton==0.5.1
+sphinx-copybutton==0.5.2


### PR DESCRIPTION
I was not able to create the documentation locally with a recent Python 3.11 installation. The versions of some sub-dependencies differ between Python 3.8 and Python 3.11. One of the sub-dependencies from packages specified in `docs/requirements.txt` expects a more recent Sphinx version `>=5`:

```sh
Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
```

This PR fixes this and other (`Node.js`) issues:

![image](https://github.com/mala-project/mala/assets/28047702/11c73e45-b08b-4a00-ac4a-8ab35295bd6b)
