### PR TITLE
Restrict usage of cache to PRs:

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Restore cache
         uses: actions/cache@v3
         id: cache-docker
+        if: github.event_name == 'pull_request'
         with:
           path: ${{ env.DOCKER_CACHE_PATH }}
           key: ${{ github.run_id }}


### PR DESCRIPTION
Usage of the cache should speed up *multiple* workflow runs within PRs for fixing failed tests etc. So far even for pushes to `develop` and `master` branches (merge commit of PRs) the Docker image is also uploaded to the cache, but most likely won't get used afterwards and hence only occupies cached storage.