### PR TITLE
Added RODARE download

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -171,13 +171,20 @@ jobs:
           # `requirements.txt` and/or extra dependencies are missing in the Docker Conda environment
           diff env_1.yml env_2.yml
 
-      - name: Check out repository (data)
-        uses: actions/checkout@v3
-        with:
-          repository: mala-project/test-data
-          path: mala_data
-          ref: v1.7.0
-          lfs: true
+      - name: Download test data repository
+        shell: 'bash -c "docker exec -i mala-cpu bash < {0}"'
+        run: |
+          # Download test data repository from RODARE. If the version changes
+          # this URL has to be adapted (the 29xx number and the version have 
+          # to be incremented)
+          wget "https://rodare.hzdr.de/record/2901/files/mala-project/test-data-v1.7.4.zip"
+          
+          # Once downloaded, we have to unzip the file. The name of the root
+          # folder in the zip file has to be updated for data repository
+          # updates as well - the string at the end is the hash of the data 
+          # repository commit. 
+          unzip test-data-v1.7.4.zip
+          mv mala-project-test-data-a6458c5 mala_data
 
       - name: Test mala
         shell: 'bash -c "docker exec -i mala-cpu bash < {0}"'


### PR DESCRIPTION
This PR enables download of data repository from RODARE instead of Github, to avoid download quoat issues. 