### PR TITLE
Revert "Restrict usage of cache to PRs:"

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Restore cache
         uses: actions/cache@v3
         id: cache-docker
-        if: github.event_name == 'pull_request'
         with:
           path: ${{ env.DOCKER_CACHE_PATH }}
           key: ${{ github.run_id }}


### PR DESCRIPTION
This reverts commit 138b8a79d554a6f98e58f0c3b080612d3feda2e7 and should fix the CI cpu-tests jobs for pushes to `develop` or `master`. I need to figure out a better way on how to clean caches after pushes to these branches.