### PR TITLE
Allow CI runs for normal PRs, but avoid runs for draft PRs

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -5,6 +5,9 @@ on:
     # Trigger on pull requests to master or develop that are
     # marked as "ready for review" (non-draft PRs)
     types:
+      - opened
+      - synchronize
+      - reopened
       - ready_for_review
     branches:
       - master
@@ -24,6 +27,8 @@ env:
 
 jobs:
   build-docker-image-cpu:
+    # do not trigger on draft PRs
+    if: ${{ ! github.event.pull_request.draft }}
     # Build and push temporary Docker image to GitHub's container registry
     runs-on: ubuntu-22.04
     steps:
@@ -174,14 +179,14 @@ jobs:
         shell: 'bash -c "docker exec -i mala-cpu bash < {0}"'
         run: |
           # Download test data repository from RODARE. If the version changes
-          # this URL has to be adapted (the number after /record/ and the 
+          # this URL has to be adapted (the number after /record/ and the
           # version have to be incremented)
           wget "https://rodare.hzdr.de/record/2999/files/mala-project/test-data-1.8.0.zip"
-          
+
           # Once downloaded, we have to unzip the file. The name of the root
           # folder in the zip file has to be updated for data repository
-          # updates as well - the string at the end is the hash of the data 
-          # repository commit. 
+          # updates as well - the string at the end is the hash of the data
+          # repository commit.
           unzip -q test-data-1.8.0.zip
           mv mala-project-test-data-d5694c7  mala_data
 
@@ -247,4 +252,3 @@ jobs:
 
       - name: Push Docker image
         run: docker push $IMAGE_REPO/$IMAGE_NAME --all-tags
-

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,6 +3,9 @@ name: Documenation
 on:
   pull_request:
     types:
+      - opened
+      - synchronize
+      - reopened
       - ready_for_review
     branches:
       - master
@@ -13,6 +16,8 @@ on:
 
 jobs:
   test-docstrings:
+    # do not trigger on draft PRs
+    if: ${{ ! github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository


### PR DESCRIPTION
Finally closes #514

Specifying `if: ${{ ! github.event.pull_request.draft }}` is only required for the first job in `cpu-tests.yml` and `gh-paages.yml` as subsequent jobs in the respective workflow files depend on the first job. This means that if the first job is skipped due to a PR draft, all dependent jobs are also skipped, which is what we intend.

![image](https://github.com/mala-project/mala/assets/28047702/cb755d44-a753-46b0-be65-a6798e97e548)
