### PR TITLE
openPMD I/O: fix parallel flushing

### DIFF
--- a/mala/common/physical_data.py
+++ b/mala/common/physical_data.py
@@ -642,6 +642,11 @@ match the array dimensions (extent {} in the feature dimension)""".format(
 
         # Third loop: Extra flushes to harmonize ranks
         for _ in range(extra_flushes):
+            # This following line is a workaround for issue
+            # https://github.com/openPMD/openPMD-api/issues/1616
+            # Fixed in openPMD-api 0.16 by
+            # https://github.com/openPMD/openPMD-api/pull/1619
+            iteration.dt = iteration.dt
             iteration.series_flush()
 
         iteration.close(flush=True)


### PR DESCRIPTION
This introduces a workaround for a parallel flushing bug in openPMD-api <= v0.15, see https://github.com/openPMD/openPMD-api/issues/1616 for the original issue and https://github.com/openPMD/openPMD-api/issues/1616 for the fix.
A fixed version is not yet released but it will be v0.16.
tldr version: explicitly write some Iteration attribute (here: `dt`) again to mark the Iteration as dirty so that the flushing logic will not accidentally skip it for collective flush operations.