### PR TITLE
Use RODARE api instead of hard coded URL:

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -179,7 +179,7 @@ jobs:
       - name: Download test data repository from RODARE
         shell: 'bash -c "docker exec -i mala-cpu python < {0}"'
         run: |
-          import requests
+          import requests, shutil, zipfile
 
           # This DOI represents all versions, and will always resolve to the latest one
           DOI = "https://doi.org/10.14278/rodare.2900"
@@ -200,16 +200,16 @@ jobs:
           # TODO: implement some sort of auto retry for failed HTTP requests
           response = requests.get(download_link)
 
-          # Saving Downloaded Content to a File
+          # Saving downloaded content to a file
           with open("test-data.zip", mode="wb") as file:
             file.write(response.content)
 
-          # Once downloaded, we have to unzip the file. The name of the root
-          # folder in the zip file has to be updated for data repository
-          # updates as well - the string at the end is the hash of the data
-          # repository commit.
-          #unzip -q test-data-1.8.1.zip
-          #mv mala-project-test-data-741eda6 mala_data
+          # Get top level directory name
+          dir_name = zipfile.ZipFile("test-data.zip").namelist()[0]
+          shutil.unpack_archive("test-data.zip", ".")
+
+          print(f"Rename {dir_name} to mala_data")
+          shutil.move(dir_name, "mala_data")
 
       - name: Test mala
         shell: 'bash -c "docker exec -i mala-cpu bash < {0}"'


### PR DESCRIPTION
It is better to use the DOI, which always refers to the latest version of the test data repo. This avoids updating the CI at several places each time there is a new version of the test data repo.

Closes  #537