### PR TITLE
Use legacy builder to build Docker image

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -74,7 +74,7 @@ jobs:
             CACHE=$IMAGE_REPO/$IMAGE_NAME:latest
           fi
 
-          docker build . --file Dockerfile --tag $IMAGE_NAME:local --cache-from=$CACHE --build-arg DEVICE=cpu
+          DOCKER_BUILDKIT=0 docker build . --file Dockerfile --tag $IMAGE_NAME:local --cache-from=$CACHE --build-arg DEVICE=cpu
 
           # Show images
           docker images --filter=reference=$IMAGE_NAME --filter=reference=$IMAGE_REPO/$IMAGE_NAME


### PR DESCRIPTION
This is a temporary fix to make the caching mechanism in the CI work again. Its currently broken due to a switch to BuildKit as the default builder for Docker Engine as of version 23.0 (2023-02-01), see https://docs.docker.com/engine/release-notes/23.0/#2300.

Closes  #527