### PR TITLE
MALA for 2D materials

### DIFF
--- a/external_modules/total_energy_module/total_energy.f90
+++ b/external_modules/total_energy_module/total_energy.f90
@@ -250,11 +250,14 @@ SUBROUTINE init_run_setup(calculate_eigts)
      CALL ggen( dfftp, gamma_only, at, bg, gcutm, ngm_g, ngm, &
        g, gg, mill, ig_l2g, gstart )
   END IF
+
+
+  IF (do_cutoff_2D) CALL cutoff_fact()
+
   !
   !  This seems to be needed by set_rhoc()
   !
   CALL gshells ( lmovecell )
-
   !
   ! ... allocate memory for structure factors
   !

--- a/mala/common/parameters.py
+++ b/mala/common/parameters.py
@@ -509,6 +509,13 @@ class ParametersTargets(ParametersBase):
 
         kMax : float
             Maximum wave vector up to which to calculate the SSF.
+
+    assume_two_dimensional : bool
+        If True, the total energy calculations will be performed without
+        periodic boundary conditions in z-direction, i.e., the cell will
+        be truncated in the z-direction. NOTE: This parameter may be
+        moved up to a global parameter, depending on whether descriptor
+        calculation may benefit from it.
     """
 
     def __init__(self):
@@ -522,6 +529,7 @@ class ParametersTargets(ParametersBase):
         self.rdf_parameters = {"number_of_bins": 500, "rMax": "mic"}
         self.tpcf_parameters = {"number_of_bins": 20, "rMax": "mic"}
         self.ssf_parameters = {"number_of_bins": 100, "kMax": 12.0}
+        self.assume_two_dimensional = False
 
     @property
     def restrict_targets(self):

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -945,12 +945,18 @@ class Density(Target):
             if self.parameters.assume_two_dimensional:
                 qe_input_data["assume_isolated"] = "2D"
 
+                # In the 2D case, the Gamma point approximation introduces
+                # errors in the Ewald and Hartree energy for some reason.
+                kpoints = [1, 1, 1]
+            else:
+                kpoints = self.kpoints
+
             self.write_tem_input_file(
                 atoms_Angstrom,
                 qe_input_data,
                 qe_pseudopotentials,
                 self.grid_dimensions,
-                self.kpoints,
+                kpoints,
             )
 
         # initialize the total energy module.

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -942,6 +942,9 @@ class Density(Target):
             if qe_pseudopotentials is None:
                 qe_pseudopotentials = self.qe_pseudopotentials
 
+            if self.parameters.assume_two_dimensional:
+                qe_input_data["assume_isolated"] = "2D"
+
             self.write_tem_input_file(
                 atoms_Angstrom,
                 qe_input_data,


### PR DESCRIPTION
This PR allows to perform TEM calculations (and, eventually, LAMMPS runs) for systems calculated using the 2D option of Quantum ESPRESSO ("assume_isolated = '2D'"). Basic calculations are already working, but there are currently still a few limitations:

- [ ] There is the issue of the general one-electron contribution bug, which also affects this PR (and generally non-metallic systems?)
- [ ] I haven't tested 2D systems with Gaussian descriptors or bispectrum calculations, there may be small adjustments necessary there