### PR TITLE
Use tempfile module for lammps file generation

### DIFF
--- a/mala/descriptors/atomic_density.py
+++ b/mala/descriptors/atomic_density.py
@@ -137,9 +137,8 @@ class AtomicDensity(Descriptor):
         keep_logs = kwargs.get("keep_logs", False)
 
         lammps_format = "lammps-data"
-        self.lammps_temporary_input = os.path.join(
-            outdir, "lammps_input_" + self.calculation_timestamp + ".tmp"
-        )
+        self.setup_lammps_tmp_files("ggrid", outdir)
+
         ase.io.write(
             self.lammps_temporary_input, self.atoms, format=lammps_format
         )
@@ -160,10 +159,6 @@ class AtomicDensity(Descriptor):
             "sigma": self.parameters.atomic_density_sigma,
             "rcutfac": self.parameters.atomic_density_cutoff,
         }
-        self.lammps_temporary_log = os.path.join(
-            outdir,
-            "lammps_ggrid_log_" + self.calculation_timestamp + ".tmp",
-        )
         lmp = self._setup_lammps(nx, ny, nz, lammps_dict)
 
         # For now the file is chosen automatically, because this is used

--- a/mala/descriptors/bispectrum.py
+++ b/mala/descriptors/bispectrum.py
@@ -142,11 +142,8 @@ class Bispectrum(Descriptor):
         keep_logs = kwargs.get("keep_logs", False)
 
         lammps_format = "lammps-data"
-        self.lammps_tmp_input_file = tempfile.NamedTemporaryFile(
-            delete=1 - keep_logs, prefix="lammps_tmp_input_", dir=outdir
-        )
-        self.lammps_temporary_input = self.lammps_tmp_input_file.name
-        printout(self.lammps_temporary_input)
+        self.setup_lammps_tmp_files("bgrid", outdir)
+
         ase.io.write(
             self.lammps_temporary_input, self.atoms, format=lammps_format
         )
@@ -160,11 +157,6 @@ class Bispectrum(Descriptor):
             "twojmax": self.parameters.bispectrum_twojmax,
             "rcutfac": self.parameters.bispectrum_cutoff,
         }
-        self.lammps_tmp_log_file = tempfile.NamedTemporaryFile(
-            delete=1 - keep_logs, prefix="lammps_tmp_bgrid_log_", dir=outdir
-        )
-        self.lammps_temporary_log = self.lammps_tmp_log_file.name
-        printout(self.lammps_temporary_log)
         lmp = self._setup_lammps(nx, ny, nz, lammps_dict)
 
         # An empty string means that the user wants to use the standard input.
@@ -232,7 +224,7 @@ class Bispectrum(Descriptor):
             )
 
             printout("Cleaning calculation")
-            self._clean_calculation(lmp)
+            self._clean_calculation(lmp, keep_logs)
 
             # Copy the grid dimensions only at the end.
             self.grid_dimensions = [nx, ny, nz]
@@ -250,7 +242,7 @@ class Bispectrum(Descriptor):
             )
 
             printout("Cleaning calculation")
-            self._clean_calculation(lmp)
+            self._clean_calculation(lmp, keep_logs)
 
             # switch from x-fastest to z-fastest order (swaps 0th and 2nd
             # dimension)

--- a/mala/descriptors/bispectrum.py
+++ b/mala/descriptors/bispectrum.py
@@ -1,6 +1,7 @@
 """Bispectrum descriptor class."""
 
 import os
+import tempfile
 
 import ase
 import ase.io
@@ -141,9 +142,11 @@ class Bispectrum(Descriptor):
         keep_logs = kwargs.get("keep_logs", False)
 
         lammps_format = "lammps-data"
-        self.lammps_temporary_input = os.path.join(
-            outdir, "lammps_input_" + self.calculation_timestamp + ".tmp"
+        self.lammps_tmp_input_file = tempfile.NamedTemporaryFile(
+            delete=1 - keep_logs, prefix="lammps_tmp_input_", dir=outdir
         )
+        self.lammps_temporary_input = self.lammps_tmp_input_file.name
+        printout(self.lammps_temporary_input)
         ase.io.write(
             self.lammps_temporary_input, self.atoms, format=lammps_format
         )
@@ -157,11 +160,11 @@ class Bispectrum(Descriptor):
             "twojmax": self.parameters.bispectrum_twojmax,
             "rcutfac": self.parameters.bispectrum_cutoff,
         }
-
-        self.lammps_temporary_log = os.path.join(
-            outdir,
-            "lammps_bgrid_log_" + self.calculation_timestamp + ".tmp",
+        self.lammps_tmp_log_file = tempfile.NamedTemporaryFile(
+            delete=1 - keep_logs, prefix="lammps_tmp_bgrid_log_", dir=outdir
         )
+        self.lammps_temporary_log = self.lammps_tmp_log_file.name
+        printout(self.lammps_temporary_log)
         lmp = self._setup_lammps(nx, ny, nz, lammps_dict)
 
         # An empty string means that the user wants to use the standard input.
@@ -227,7 +230,9 @@ class Bispectrum(Descriptor):
                 array_shape=(nrows_local, ncols_local),
                 use_fp64=use_fp64,
             )
-            self._clean_calculation(lmp, keep_logs)
+
+            printout("Cleaning calculation")
+            self._clean_calculation(lmp)
 
             # Copy the grid dimensions only at the end.
             self.grid_dimensions = [nx, ny, nz]
@@ -243,7 +248,9 @@ class Bispectrum(Descriptor):
                 (nz, ny, nx, self.fingerprint_length),
                 use_fp64=use_fp64,
             )
-            self._clean_calculation(lmp, keep_logs)
+
+            printout("Cleaning calculation")
+            self._clean_calculation(lmp)
 
             # switch from x-fastest to z-fastest order (swaps 0th and 2nd
             # dimension)
@@ -511,7 +518,6 @@ class Bispectrum(Descriptor):
     ########
 
     class _ZIndices:
-
         def __init__(self):
             self.j1 = 0
             self.j2 = 0
@@ -525,7 +531,6 @@ class Bispectrum(Descriptor):
             self.jju = 0
 
     class _BIndices:
-
         def __init__(self):
             self.j1 = 0
             self.j2 = 0
@@ -968,21 +973,21 @@ class Bispectrum(Descriptor):
                     )
                     jju1 += 1
                 if jju_outer in self.__index_u1_symmetry_pos:
-                    ulist_r_ij[:, self.__index_u1_symmetry_pos[jju2]] = (
-                        ulist_r_ij[:, self.__index_u_symmetry_pos[jju2]]
-                    )
-                    ulist_i_ij[:, self.__index_u1_symmetry_pos[jju2]] = (
-                        -ulist_i_ij[:, self.__index_u_symmetry_pos[jju2]]
-                    )
+                    ulist_r_ij[
+                        :, self.__index_u1_symmetry_pos[jju2]
+                    ] = ulist_r_ij[:, self.__index_u_symmetry_pos[jju2]]
+                    ulist_i_ij[
+                        :, self.__index_u1_symmetry_pos[jju2]
+                    ] = -ulist_i_ij[:, self.__index_u_symmetry_pos[jju2]]
                     jju2 += 1
 
                 if jju_outer in self.__index_u1_symmetry_neg:
-                    ulist_r_ij[:, self.__index_u1_symmetry_neg[jju3]] = (
-                        -ulist_r_ij[:, self.__index_u_symmetry_neg[jju3]]
-                    )
-                    ulist_i_ij[:, self.__index_u1_symmetry_neg[jju3]] = (
-                        ulist_i_ij[:, self.__index_u_symmetry_neg[jju3]]
-                    )
+                    ulist_r_ij[
+                        :, self.__index_u1_symmetry_neg[jju3]
+                    ] = -ulist_r_ij[:, self.__index_u_symmetry_neg[jju3]]
+                    ulist_i_ij[
+                        :, self.__index_u1_symmetry_neg[jju3]
+                    ] = ulist_i_ij[:, self.__index_u_symmetry_neg[jju3]]
                     jju3 += 1
 
             # This emulates add_uarraytot.

--- a/mala/descriptors/bispectrum.py
+++ b/mala/descriptors/bispectrum.py
@@ -223,7 +223,6 @@ class Bispectrum(Descriptor):
                 use_fp64=use_fp64,
             )
 
-            printout("Cleaning calculation")
             self._clean_calculation(lmp, keep_logs)
 
             # Copy the grid dimensions only at the end.
@@ -241,7 +240,6 @@ class Bispectrum(Descriptor):
                 use_fp64=use_fp64,
             )
 
-            printout("Cleaning calculation")
             self._clean_calculation(lmp, keep_logs)
 
             # switch from x-fastest to z-fastest order (swaps 0th and 2nd

--- a/mala/descriptors/descriptor.py
+++ b/mala/descriptors/descriptor.py
@@ -820,16 +820,10 @@ class Descriptor(PhysicalData):
 
         return lmp
 
-    def _clean_calculation(self, lmp, keep_logs):
+    def _clean_calculation(self, lmp):
         lmp.close()
-        if not keep_logs:
-            if get_rank() == 0:
-                os.remove(self.lammps_temporary_log)
-                os.remove(self.lammps_temporary_input)
-
-        # Reset timestamp for potential next calculation using same LAMMPS
-        # object.
-        del self.calculation_timestamp
+        self.lammps_tmp_input_file.close()
+        self.lammps_tmp_log_file.close()
 
     def _setup_atom_list(self):
         """

--- a/mala/descriptors/minterpy_descriptors.py
+++ b/mala/descriptors/minterpy_descriptors.py
@@ -163,9 +163,8 @@ class MinterpyDescriptors(Descriptor):
 
             # The rest is the stanfard LAMMPS atomic density stuff.
             lammps_format = "lammps-data"
-            self.lammps_temporary_input = os.path.join(
-                outdir, "lammps_input_" + self.calculation_timestamp + ".tmp"
-            )
+            self.setup_lammps_tmp_files("minterpy", outdir)
+
             ase.io.write(
                 self.lammps_temporary_input, self.atoms, format=lammps_format
             )
@@ -175,10 +174,6 @@ class MinterpyDescriptors(Descriptor):
                 "sigma": self.parameters.atomic_density_sigma,
                 "rcutfac": self.parameters.atomic_density_cutoff,
             }
-            self.lammps_temporary_log = os.path.join(
-                outdir,
-                "lammps_bgrid_log_" + self.calculation_timestamp + ".tmp",
-            )
             lmp = self._setup_lammps(nx, ny, nz, lammps_dict)
 
             # For now the file is chosen automatically, because this is used


### PR DESCRIPTION
This PR uses Python's `tempfile` module to generate the names for the temporary lammps files (#525). It should avoid the issues we had using the timestamp to generate unique names.