### PR TITLE
Flexible snapshot number for data shuffling

### DIFF
--- a/mala/datahandling/data_shuffler.py
+++ b/mala/datahandling/data_shuffler.py
@@ -130,11 +130,33 @@ class DataShuffler(DataHandlerBase):
                 )
             )
 
+            # if the number of new snapshots is not a divisor of the grid size
+            # then we have to trim the original snapshots to size
+            # the indicies to be removed are selected at random
+            if self.data_points_to_remove is not None:
+                if self.parameters.shuffling_seed is not None:
+                    np.random.seed(idx * self.parameters.shuffling_seed)
+                ngrid = descriptor_data[idx].shape[0]
+                n_desciptor = descriptor_data[idx].shape[-1]
+                n_target = target_data[idx].shape[-1]
+
+                current_target = target_data[idx].reshape(-1, n_target)
+                current_descriptor = target_data[idx].reshape(-1, n_descriptor)
+
+                indices = np.random.choice(
+                    ngrid, size=ngrid - self.data_points_to_remove[idx]
+                )
+
+                descriptor_data[idx] = current_descriptor[indices]
+                target_data[idx] = current_target[indicies]
+
         # Do the actual shuffling.
-        target_name_openpmd = os.path.join(target_save_path,
-                                       save_name.replace("*", "%T"))
-        descriptor_name_openpmd = os.path.join(descriptor_save_path,
-                                        save_name.replace("*", "%T"))
+        target_name_openpmd = os.path.join(
+            target_save_path, save_name.replace("*", "%T")
+        )
+        descriptor_name_openpmd = os.path.join(
+            descriptor_save_path, save_name.replace("*", "%T")
+        )
         for i in range(0, number_of_new_snapshots):
             new_descriptors = np.zeros(
                 (int(np.prod(shuffle_dimensions)), self.input_dimension),
@@ -163,16 +185,12 @@ class DataShuffler(DataHandlerBase):
                 )
                 new_descriptors[
                     last_start : current_chunk + last_start
-                ] = descriptor_data[j].reshape(
-                    current_grid_size, self.input_dimension
-                )[
+                ] = descriptor_data[j].reshape(-1, self.input_dimension)[
                     i * current_chunk : (i + 1) * current_chunk, :
                 ]
                 new_targets[
                     last_start : current_chunk + last_start
-                ] = target_data[j].reshape(
-                    current_grid_size, self.output_dimension
-                )[
+                ] = target_data[j].reshape(-1, self.output_dimension)[
                     i * current_chunk : (i + 1) * current_chunk, :
                 ]
 
@@ -238,7 +256,6 @@ class DataShuffler(DataHandlerBase):
     # It will be executed one after another for both of them.
     # Use this class to parameterize which of both should be shuffled.
     class __DescriptorOrTarget:
-
         def __init__(
             self,
             save_path,
@@ -256,7 +273,6 @@ class DataShuffler(DataHandlerBase):
             self.dimension = dimension
 
     class __MockedMPIComm:
-
         def __init__(self):
             self.rank = 0
             self.size = 1
@@ -363,9 +379,7 @@ class DataShuffler(DataHandlerBase):
         import json
 
         # Do the actual shuffling.
-        name_prefix = os.path.join(
-            dot.save_path, save_name.replace("*", "%T")
-        )
+        name_prefix = os.path.join(dot.save_path, save_name.replace("*", "%T"))
         for i in range(my_items_start, my_items_end):
             # We check above that in the non-numpy case, OpenPMD will work.
             dot.calculator.grid_dimensions = list(shuffle_dimensions)
@@ -584,11 +598,37 @@ class DataShuffler(DataHandlerBase):
                 del specified_number_of_new_snapshots
 
             if number_of_data_points % number_of_new_snapshots != 0:
-                raise Exception(
-                    "Cannot create this number of snapshots "
-                    "from data provided."
-                )
+                if snapshot_type == numpy:
+                    self.data_points_to_remove = []
+                    for i in range(0, self.nr_snapshots):
+                        gridsize = self.parameters.directories_list[
+                            i
+                        ].grid_size
+                        shuffled_gridsize = int(
+                            gridsize / number_of_new_snapshots
+                        )
+                        self.data_points_to_remove.append(
+                            gridsize
+                            - shuffled_gridsize * number_of_new_snapshots
+                        )
+                    tot_points_missing = sum(self.data_points_to_remove)
+
+                    raise Warning(
+                        "Number of requested snapshots is not a divisor of the original grid sizes.\n"
+                        + str(tot_points_missing)
+                        + "/"
+                        + str(number_of_data_points)
+                        + " will be left out of the shuffled snapshots."
+                    )
+
+                elif snapshot_type == "openpmd":
+                    # TODO implement arbitrary grid sizes for openpmd
+                    raise Exception(
+                        "Cannot create this number of snapshots "
+                        "from data provided."
+                    )
             else:
+                self.data_points_to_remove = None
                 shuffle_dimensions = [
                     int(number_of_data_points / number_of_new_snapshots),
                     1,
@@ -606,7 +646,6 @@ class DataShuffler(DataHandlerBase):
         permutations = []
         seeds = []
         for i in range(0, number_of_new_snapshots):
-
             # This makes the shuffling deterministic, if specified by the user.
             if self.parameters.shuffling_seed is not None:
                 np.random.seed(i * self.parameters.shuffling_seed)


### PR DESCRIPTION
This PR allows the user to specify an arbitrary number of snapshots during the data shuffling procedure, even if the snapshot number isn't an exact divisor of the number of grid points in each snapshot.

In the non-exact-divisor case, a very small number of data points is "left out". To give an idea what very small means, consider a typical grid of 200x200x200 points, and a user requesting up to 10,000 snapshots. From the graph below, we can see that no more than ~0.1% of the initial data is left out in any of these choices.

![Screenshot from 2024-08-14 13-10-54](https://github.com/user-attachments/assets/625ba7fd-388a-405e-9d0d-783a95eac106)

This PR is a fix for issue #509.

Right now, I've implemented this only for the numpy case, so it's not possible with openPMD. Frankly I've no idea how to do it for the latter. I don't know how many users are currently using openPMD AND want to use an arbitrary snapshot number, if the answer is ~0 then we can just keep this as a todo for the future.

As mentioned in issue #564, I think the whole shuffling procedure could be simplified. But this PR ignores that possibility and integrates the new functionality into the code without making other changes.