### PR TITLE
Align LDOS vectors to a reference

### DIFF
--- a/examples/advanced/ex09_align_ldos.py
+++ b/examples/advanced/ex09_align_ldos.py
@@ -1,0 +1,32 @@
+import os
+
+import mala
+
+from mala.datahandling.data_repo import data_path
+
+"""
+Shows how to align the energy spaces of different LDOS vectors to a reference.
+This is useful when the band energy spectrum starts at different values, e.g.
+when MALA is trained for snapshots of different mass densities.
+
+Note that this example is only a proof-of-principle, because the alignment
+algorithm has no effect on the Be test snapshots (apart from truncation).
+"""
+
+
+parameters = mala.Parameters()
+parameters.targets.ldos_gridoffset_ev = -5
+parameters.targets.ldos_gridsize = 11
+parameters.targets.ldos_gridspacing_ev = 2.5
+
+# initialize and add snapshots to workflow
+ldos_aligner = mala.LDOSAlign(parameters)
+ldos_aligner.clear_data()
+ldos_aligner.add_snapshot("Be_snapshot0.out.npy", data_path)
+ldos_aligner.add_snapshot("Be_snapshot1.out.npy", data_path)
+ldos_aligner.add_snapshot("Be_snapshot2.out.npy", data_path)
+
+# align and cut the snapshots from the left and right-hand sides
+ldos_aligner.align_ldos_to_ref(
+    left_truncate=True, right_truncate_value=11, number_of_electrons=4
+)

--- a/examples/advanced/ex09_align_ldos.py
+++ b/examples/advanced/ex09_align_ldos.py
@@ -20,7 +20,7 @@ parameters.targets.ldos_gridsize = 11
 parameters.targets.ldos_gridspacing_ev = 2.5
 
 # initialize and add snapshots to workflow
-ldos_aligner = mala.LDOSAlign(parameters)
+ldos_aligner = mala.LDOSAligner(parameters)
 ldos_aligner.clear_data()
 ldos_aligner.add_snapshot("Be_snapshot0.out.npy", data_path)
 ldos_aligner.add_snapshot("Be_snapshot1.out.npy", data_path)

--- a/mala/__init__.py
+++ b/mala/__init__.py
@@ -26,7 +26,7 @@ from .datahandling import (
     DataConverter,
     Snapshot,
     DataShuffler,
-    LDOSAlign,
+    LDOSAligner,
 )
 from .network import (
     Network,

--- a/mala/__init__.py
+++ b/mala/__init__.py
@@ -26,6 +26,7 @@ from .datahandling import (
     DataConverter,
     Snapshot,
     DataShuffler,
+    LDOSAlign,
 )
 from .network import (
     Network,

--- a/mala/datahandling/__init__.py
+++ b/mala/datahandling/__init__.py
@@ -5,3 +5,4 @@ from .data_scaler import DataScaler
 from .data_converter import DataConverter
 from .snapshot import Snapshot
 from .data_shuffler import DataShuffler
+from .ldos_align import LDOSAlign

--- a/mala/datahandling/__init__.py
+++ b/mala/datahandling/__init__.py
@@ -5,4 +5,4 @@ from .data_scaler import DataScaler
 from .data_converter import DataConverter
 from .snapshot import Snapshot
 from .data_shuffler import DataShuffler
-from .ldos_align import LDOSAlign
+from .ldos_aligner import LDOSAligner

--- a/mala/datahandling/ldos_align.py
+++ b/mala/datahandling/ldos_align.py
@@ -212,7 +212,9 @@ class LDOSAlign(DataHandlerBase):
             )
 
             # get the mean
-            ngrid = ldos.shape[0]
+            nx = ldos.shape[0]
+            ny = ldos.shape[1]
+            nz = ldos.shape[2]
             ldos = ldos.reshape(-1, n_target)
             ldos_shifted = np.zeros_like(ldos)
             ldos_mean = np.mean(ldos, axis=0)
@@ -256,7 +258,7 @@ class LDOSAlign(DataHandlerBase):
                 new_egrid_offset = self.ldos_parameters.ldos_gridoffset_ev
 
             # reshape
-            ldos_shifted = ldos_shifted.reshape(ngrid, ngrid, ngrid, -1)
+            ldos_shifted = ldos_shifted.reshape(nx, ny, nz, -1)
 
             ldos_shift_info = {
                 "ldos_shift_ev": round(e_shift, 4),
@@ -299,12 +301,12 @@ class LDOSAlign(DataHandlerBase):
             with open(
                 os.path.join(save_path, ldos_shift_info_save_name), "w"
             ) as f:
-                json.dump(ldos_shift_info, f)
+                json.dump(ldos_shift_info, f, indent=2)
 
         barrier()
-
+    
+    @staticmethod
     def calc_optimal_ldos_shift(
-        self,
         e_grid,
         ldos_mean,
         ldos_mean_ref,

--- a/mala/datahandling/ldos_aligner.py
+++ b/mala/datahandling/ldos_aligner.py
@@ -15,7 +15,7 @@ from mala.datahandling.data_handler_base import DataHandlerBase
 from mala.common.parallelizer import get_comm
 
 
-class LDOSAlign(DataHandlerBase):
+class LDOSAligner(DataHandlerBase):
     """
     Align LDOS vectors based on when they first become non-zero.
 
@@ -42,7 +42,7 @@ class LDOSAlign(DataHandlerBase):
         descriptor_calculator=None,
     ):
         self.ldos_parameters = parameters.targets
-        super(LDOSAlign, self).__init__(
+        super(LDOSAligner, self).__init__(
             parameters,
             target_calculator=target_calculator,
             descriptor_calculator=descriptor_calculator,
@@ -68,7 +68,7 @@ class LDOSAlign(DataHandlerBase):
         snapshot_type : string
             Must be numpy, openPMD is not yet available for LDOS alignment.
         """
-        super(LDOSAlign, self).add_snapshot(
+        super(LDOSAligner, self).add_snapshot(
             "",
             "",
             output_file,


### PR DESCRIPTION
Aligns a set of LDOS vectors to a reference. Optionally, the LDOS vectors can also be truncated from the left and right. This makes learning easier when the LDOS vectors become non-zero at different points, and/or are truncated (due to finite number of bands) at different points, such as when different mass densities are considered.

Remaining tasks need to be done or at least discussed before merging:

- [x] Parallelize over snapshots
- [x] Add alignment test
- [ ] ~~Extend to snapshots stored as openPMD~~
- [ ] ~~Include additional information files~~