### PR TITLE
Change default units when reading from cube files

### DIFF
--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -102,7 +102,7 @@ class Density(Target):
         return return_dos
 
     @classmethod
-    def from_cube_file(cls, params, path, units="1/A^3"):
+    def from_cube_file(cls, params, path, units="1/Bohr^3"):
         """
         Create a Density calculator from a cube file.
 
@@ -391,7 +391,7 @@ class Density(Target):
         else:
             raise Exception("Unsupported unit for density.")
 
-    def read_from_cube(self, path, units="1/A^3", **kwargs):
+    def read_from_cube(self, path, units="1/Bohr^3", **kwargs):
         """
         Read the density data from a cube file.
 

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -404,9 +404,12 @@ class Density(Target):
             Units the density is saved in. Usually none.
         """
         printout("Reading density from .cube file ", path, min_verbosity=0)
-        if units != "1/(Ry*Bohr^3)":
+        # automatically convert units if they are None since cube files take atomic units
+        if units is None:
+            units="1/Bohr^3"
+        if units != "1/Bohr^3":
             printout(
-                "The expected units for the LDOS from cube files are 1/(Ry*Bohr^3)\n"
+                "The expected units for the density from cube files are 1/Bohr^3\n"
                 f"Proceeding with specified units of {units}\n"
                 "We recommend to check and change the requested units"
             )

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -404,6 +404,12 @@ class Density(Target):
             Units the density is saved in. Usually none.
         """
         printout("Reading density from .cube file ", path, min_verbosity=0)
+        if units != "1/(Ry*Bohr^3)":
+            printout(
+                "The expected units for the LDOS from cube files are 1/(Ry*Bohr^3)\n"
+                f"Proceeding with specified units of {units}\n"
+                "We recommend to check and change the requested units"
+            )
         data, meta = read_cube(path)
         data *= self.convert_units(1, in_units=units)
         self.density = data

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -495,6 +495,12 @@ class LDOS(Target):
         # tmp.pp003ELEMENT_ldos.cube
         # ...
         # tmp.pp100ELEMENT_ldos.cube
+        if units != "1/(Ry*Bohr^3)":
+            printout(
+                "The expected units for the LDOS from cube files are 1/(Ry*Bohr^3)\n"
+                f"Proceeding with specified units of {units}\n"
+                "We recommend to check and change the requested units"
+            )
         return self._read_from_qe_files(
             path_scheme, units, use_memmap, ".cube", **kwargs
         )

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -99,7 +99,7 @@ class LDOS(Target):
 
     @classmethod
     def from_cube_file(
-        cls, params, path_name_scheme, units="1/(eV*A^3)", use_memmap=None
+        cls, params, path_name_scheme, units="1/(Ry*Bohr^3)", use_memmap=None
     ):
         """
         Create an LDOS calculator from multiple cube files.
@@ -463,7 +463,7 @@ class LDOS(Target):
             raise Exception("Unsupported unit for LDOS.")
 
     def read_from_cube(
-        self, path_scheme, units="1/(eV*A^3)", use_memmap=None, **kwargs
+        self, path_scheme, units="1/(Ry*Bohr^3)", use_memmap=None, **kwargs
     ):
         """
         Read the LDOS data from multiple cube files.

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -495,6 +495,9 @@ class LDOS(Target):
         # tmp.pp003ELEMENT_ldos.cube
         # ...
         # tmp.pp100ELEMENT_ldos.cube
+        # automatically convert units if they are None since cube files take atomic units
+        if units is None:
+            units = "1/(Ry*Bohr^3)"
         if units != "1/(Ry*Bohr^3)":
             printout(
                 "The expected units for the LDOS from cube files are 1/(Ry*Bohr^3)\n"


### PR DESCRIPTION
This PR addresses issue #576.

According to the Gaussian [documentation](https://gaussian.com/cubegen/), cube files are almost always in atomic units, and this is certainly the units used by QE, so it should be safe to make this assumption. 

I simply changed the default units for the `read_from_cube` functions. 

I also added a warning statement if users explicitly request the wrong units.