### PR TITLE
Revert pydocstyle command

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Check docstrings
          # Ignoring the cached_properties because pydocstyle (sometimes?) treats them as functions.
-        run: pydocstyle --convention=numpy --ignore-decorators=[cached_property,property] mala
+        run: pydocstyle --convention=numpy mala
 
   build-and-deploy-pages:
     needs: test-docstrings

--- a/mala/interfaces/ase_calculator.py
+++ b/mala/interfaces/ase_calculator.py
@@ -79,7 +79,7 @@ class MALA(Calculator):
     @classmethod
     def load_model(cls, run_name, path="./"):
         """
-        DEPRECATED: Load a model to use for the calculator.
+        Load a model to use for the calculator (DEPRECATED).
 
         MALA.load_model() will be deprecated in MALA v1.4.0. Please use
         MALA.load_run() instead.
@@ -234,5 +234,5 @@ class MALA(Calculator):
 
         """
         self.predictor.save_run(
-            filename, path=save_path, additional_calculation_data=True
+            filename, path=path, additional_calculation_data=True
         )


### PR DESCRIPTION
Since pydocstyle has been updated, it should be possible to test the docstrings of properties as well now. 