### PR TITLE
Deprecating the name "SNAP" descriptors

### DIFF
--- a/mala/common/parameters.py
+++ b/mala/common/parameters.py
@@ -306,9 +306,9 @@ class ParametersDescriptors(ParametersBase):
                                 descriptors.
 
     bispectrum_twojmax : int
-        Bispectrum calculation: 2*jmax-parameter used for calculation of SNAP
-        descriptors. Default value for jmax is 5, so default value for
-        twojmax is 10.
+        Bispectrum calculation: 2*jmax-parameter used for calculation of
+        bispectrum descriptors. Default value for jmax is 5, so default value
+        for twojmax is 10.
 
     lammps_compute_file : string
         Bispectrum calculation: LAMMPS input file that is used to calculate the

--- a/mala/descriptors/atomic_density.py
+++ b/mala/descriptors/atomic_density.py
@@ -205,7 +205,7 @@ class AtomicDensity(Descriptor):
         )
         self._clean_calculation(lmp, keep_logs)
 
-        # In comparison to SNAP, the atomic density always returns
+        # In comparison to bispectrum, the atomic density always returns
         # in the "local mode". Thus we have to make some slight adjustments
         # if we operate without MPI.
         self.grid_dimensions = [nx, ny, nz]

--- a/mala/descriptors/descriptor.py
+++ b/mala/descriptors/descriptor.py
@@ -59,18 +59,6 @@ class Descriptor(PhysicalData):
         # Check if we're accessing through base class.
         # If not, we need to return the correct object directly.
         if cls == Descriptor:
-            if params.descriptors.descriptor_type == "SNAP":
-                from mala.descriptors.bispectrum import Bispectrum
-
-                parallel_warn(
-                    "Using 'SNAP' as descriptors will be deprecated "
-                    "starting in MALA v1.3.0. Please use 'Bispectrum' "
-                    "instead.",
-                    min_verbosity=0,
-                    category=FutureWarning,
-                )
-                descriptors = super(Descriptor, Bispectrum).__new__(Bispectrum)
-
             if params.descriptors.descriptor_type == "Bispectrum":
                 from mala.descriptors.bispectrum import Bispectrum
 
@@ -503,7 +491,7 @@ class Descriptor(PhysicalData):
             ny = self.grid_dimensions[1]
             nz = self.grid_dimensions[2]
             descriptors_full = np.zeros([nx, ny, nz, self.fingerprint_length])
-            # Fill the full SNAP descriptors array.
+            # Fill the full bispectrum descriptors array.
             for idx, local_grid in enumerate(all_descriptors_list):
                 # We glue the individual cells back together, and transpose.
                 first_x = int(local_grid[0][0])

--- a/mala/descriptors/in.bgrid.python
+++ b/mala/descriptors/in.bgrid.python
@@ -1,4 +1,4 @@
-# Calculate SNAP descriptors on a 3D grid
+# Calculate bispectrum descriptors on a 3D grid
 
 # pass in values ngridx, ngridy, ngridz, twojmax, rcutfac, atom_config_fname 
 # using command-line -var option

--- a/mala/descriptors/in.bgrid.twoelements.python
+++ b/mala/descriptors/in.bgrid.twoelements.python
@@ -1,4 +1,4 @@
-# Calculate SNAP descriptors on a 3D grid
+# Calculate bispectrum descriptors on a 3D grid
 
 # pass in values ngridx, ngridy, ngridz, twojmax, rcutfac, atom_config_fname 
 # using command-line -var option

--- a/mala/descriptors/in.bgridlocal.python
+++ b/mala/descriptors/in.bgridlocal.python
@@ -1,4 +1,4 @@
-# Calculate SNAP descriptors on a 3D grid
+# Calculate bispectrum descriptors on a 3D grid
 
 # pass in values ngridx, ngridy, ngridz, twojmax, rcutfac, atom_config_fname 
 # using command-line -var option

--- a/mala/descriptors/in.bgridlocal_defaultproc.python
+++ b/mala/descriptors/in.bgridlocal_defaultproc.python
@@ -1,4 +1,4 @@
-# Calculate SNAP descriptors on a 3D grid
+# Calculate bispectrum descriptors on a 3D grid
 
 # pass in values ngridx, ngridy, ngridz, twojmax, rcutfac, atom_config_fname
 # using command-line -var option

--- a/mala/descriptors/in.ggrid.python
+++ b/mala/descriptors/in.ggrid.python
@@ -1,4 +1,4 @@
-# Calculate SNAP descriptors on a 3D grid
+# Calculate Gaussian atomic density descriptors on a 3D grid
 
 # pass in values ngridx, ngridy, ngridz, sigma, atom_config_fname
 # using command-line -var option

--- a/mala/descriptors/in.ggrid_defaultproc.python
+++ b/mala/descriptors/in.ggrid_defaultproc.python
@@ -1,4 +1,4 @@
-# Calculate SNAP descriptors on a 3D grid
+# Calculate Gaussian atomic density descriptors on a 3D grid
 
 # pass in values ngridx, ngridy, ngridz, sigma, atom_config_fname
 # using command-line -var option


### PR DESCRIPTION
Deleted all instances of "SNAP" from MALA, as it will be deprecated starting in v1.3.0. The new term we use and encourage is "Bispectrum descriptors", to avoid confusion with SNAP as an ML-IAP.