### PR TITLE
Made a density read from a cube file a 4D array as well

### DIFF
--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -417,6 +417,7 @@ class Density(Target):
                 "We recommend to check and change the requested units"
             )
         data, meta = read_cube(path)
+        data = np.expand_dims(data, -1)
         data *= self.convert_units(1, in_units=units)
         self.density = data
         self.grid_dimensions = list(np.shape(data)[0:3])


### PR DESCRIPTION
This fixes https://github.com/mala-project/mala/issues/585 by expanding the dimensions of a density read from a cube file, thus making it compatible with MALA's internal structure of representing volumetric quantities as 4D arrays.