### PR TITLE
Extend docstrings

### DIFF
--- a/examples/advanced/ex03_tensor_board.py
+++ b/examples/advanced/ex03_tensor_board.py
@@ -32,11 +32,19 @@ parameters.running.validate_every_n_epochs = 5
 
 data_handler = mala.DataHandler(parameters)
 data_handler.add_snapshot(
-    "Be_snapshot0.in.npy", data_path, "Be_snapshot0.out.npy", data_path, "tr",
+    "Be_snapshot0.in.npy",
+    data_path,
+    "Be_snapshot0.out.npy",
+    data_path,
+    "tr",
     calculation_output_file=os.path.join(data_path, "Be_snapshot0.out"),
 )
 data_handler.add_snapshot(
-    "Be_snapshot1.in.npy", data_path, "Be_snapshot1.out.npy", data_path, "va",
+    "Be_snapshot1.in.npy",
+    data_path,
+    "Be_snapshot1.out.npy",
+    data_path,
+    "va",
     calculation_output_file=os.path.join(data_path, "Be_snapshot1.out"),
 )
 data_handler.prepare_data()

--- a/examples/advanced/ex10_convert_numpy_openpmd.py
+++ b/examples/advanced/ex10_convert_numpy_openpmd.py
@@ -29,7 +29,7 @@ data_converter.convert_snapshots(
     descriptor_save_path="./",
     target_save_path="./",
     additional_info_save_path="./",
-    naming_scheme="converted_from_numpy_*.bp5",
+    naming_scheme="converted_from_numpy_*.h5",
     descriptor_calculation_kwargs={"working_directory": "./"},
 )
 
@@ -40,11 +40,9 @@ data_converter = mala.DataConverter(parameters)
 for snapshot in range(2):
     data_converter.add_snapshot(
         descriptor_input_type="openpmd",
-        descriptor_input_path="converted_from_numpy_{}.in.bp5".format(
-            snapshot
-        ),
+        descriptor_input_path="converted_from_numpy_{}.in.h5".format(snapshot),
         target_input_type="openpmd",
-        target_input_path="converted_from_numpy_{}.out.bp5".format(snapshot),
+        target_input_path="converted_from_numpy_{}.out.h5".format(snapshot),
         additional_info_input_type=None,
         additional_info_input_path=None,
         target_units=None,

--- a/mala/common/parallelizer.py
+++ b/mala/common/parallelizer.py
@@ -5,7 +5,6 @@ import platform
 import os
 import warnings
 
-import torch
 import torch.distributed as dist
 
 use_ddp = False
@@ -154,6 +153,11 @@ def get_local_rank():
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
     DEALINGS IN THE SOFTWARE.
+
+    Returns
+    -------
+    local_rank : int
+        The local rank of the current thread.
     """
     if use_ddp:
         return int(os.environ.get("LOCAL_RANK"))
@@ -189,7 +193,6 @@ def get_size():
         return comm.Get_size()
 
 
-# TODO: This is hacky, improve it.
 def get_comm():
     """
     Return the MPI communicator, if MPI is being used.
@@ -197,7 +200,7 @@ def get_comm():
     Returns
     -------
     comm : MPI.COMM_WORLD
-        A MPI communicator.
+        An MPI communicator.
 
     """
     return comm
@@ -221,7 +224,7 @@ def printout(*values, sep=" ", min_verbosity=0):
 
     Parameters
     ----------
-    values
+    values : object
         Values to be printed.
 
     sep : string
@@ -245,7 +248,7 @@ def parallel_warn(warning, min_verbosity=0, category=UserWarning):
 
     Parameters
     ----------
-    warning
+    warning : str
         Warning to be printed.
     min_verbosity : int
         Minimum number of verbosity for this output to still be printed.

--- a/mala/common/parameters.py
+++ b/mala/common/parameters.py
@@ -773,24 +773,33 @@ class ParametersRunning(ParametersBase):
         determined by DFT reference data, and this parameter does not need to
         be set. Thus, this parameter mainly exists for debugging purposes.
 
-    use_mixed_precision :
+    use_mixed_precision : bool
         If True, mixed precision computation (via AMP) will be used.
+
+    l2_regularization : float
+        Weight decay rate for NN optimizer.
+
+    dropout : float
+        Dropout rate for positional encoding in transformer net.
+
+    training_log_interval : int
+        Number of data points after which metrics will be logged.
     """
 
     def __init__(self):
         super(ParametersRunning, self).__init__()
         self.optimizer = "Adam"
         self.learning_rate = 10 ** (-5)
-        self.learning_rate_embedding = 10 ** (-4)
+        # self.learning_rate_embedding = 10 ** (-4)
         self.max_number_epochs = 100
         self.mini_batch_size = 10
-        self.snapshots_per_epoch = -1
+        # self.snapshots_per_epoch = -1
 
-        self.l1_regularization = 0.0
+        # self.l1_regularization = 0.0
         self.l2_regularization = 0.0
         self.dropout = 0.0
-        self.batch_norm = False
-        self.input_noise = 0.0
+        # self.batch_norm = False
+        # self.input_noise = 0.0
 
         self.early_stopping_epochs = 0
         self.early_stopping_threshold = 0
@@ -799,11 +808,11 @@ class ParametersRunning(ParametersBase):
         self.learning_rate_patience = 0
         self._during_training_metric = "ldos"
         self._after_training_metric = "ldos"
-        self.use_compression = False
+        # self.use_compression = False
         self.num_workers = 0
         self.use_shuffling_for_samplers = True
         self.checkpoints_each_epoch = 0
-        self.checkpoint_best_so_far = False
+        # self.checkpoint_best_so_far = False
         self.checkpoint_name = "checkpoint_mala"
         self.run_name = ""
         self.logging_dir = "./mala_logging"

--- a/mala/common/parameters.py
+++ b/mala/common/parameters.py
@@ -169,7 +169,7 @@ class ParametersBase(JSONSerializable):
     @classmethod
     def from_json(cls, json_dict):
         """
-        Read this object from a dictionary saved in a JSON file.
+        Read parameters from a dictionary saved in a JSON file.
 
         Parameters
         ----------
@@ -276,6 +276,10 @@ class ParametersNetwork(ParametersBase):
         Number of heads to be used in Multi head attention network
         This should be a divisor of input dimension
         Default: None
+
+    dropout : float
+        Dropout rate for positional encoding in transformer.
+        Default: 0.1
     """
 
     def __init__(self):
@@ -327,7 +331,51 @@ class ParametersDescriptors(ParametersBase):
         descriptor vector. If False, no such cutting is peformed.
 
     atomic_density_sigma : float
-        Sigma used for the calculation of the Gaussian descriptors.
+        Sigma (=width) used for the calculation of the Gaussian descriptors.
+        Explicitly setting this value is discouraged if the atomic density is
+        used only during the total energy calculation and, e.g., bispectrum
+        descriptors are used for models. In this case, the width will
+        automatically be set correctly during inference based on model
+        parameters. This parameter mainly exists for debugging purposes.
+        If the atomic density is instead used for model training itself, this
+        parameter needs to be set.
+
+    atomic_density_cutoff : float
+        Cutoff radius used for atomic density calculation. Explicitly setting
+        this value is discouraged if the atomic density is used only during the
+        total energy calculation and, e.g., bispectrum descriptors are used
+        for models. In this case, the cutoff will automatically be set
+        correctly during inference based on model parameters. This parameter
+        mainly exists for debugging purposes. If the atomic density is instead
+        used for model training itself, this parameter needs to be set.
+
+    descriptor_type : str
+        Type of Descriptors used for model training. Supported are "Bispectrum"
+        and "AtomicDensity", although only the former is currently used for
+        published models.
+
+    lammps_compute_file : str
+        Path to a LAMMPS compute file for the bispectrum descriptor
+        calculation. MALA has its own collection of compute files which are
+        used by default. Setting this parameter is thus not necessarys for
+        model training and inference, and it exists mainly for debugging
+        purposes.
+
+    minterpy_cutoff_cube_size : float
+        WILL BE DEPRECATED IN MALA v1.4.0 - size of cube for minterpy
+        descriptor calculation.
+
+    minterpy_lp_norm : int
+        WILL BE DEPRECATED IN MALA v1.4.0 - LP norm for minterpy
+        descriptor calculation.
+
+    minterpy_point_list : list
+        WILL BE DEPRECATED IN MALA v1.4.0 - list of points for minterpy
+        descriptor calculation.
+
+    minterpy_polynomial_degree : int
+        WILL BE DEPRECATED IN MALA v1.4.0 - polynomial degree for minterpy
+        descriptor calculation.
     """
 
     def __init__(self):
@@ -718,6 +766,14 @@ class ParametersRunning(ParametersBase):
         List with two entries determining with which batch/iteration number
          the CUDA profiler will start and stop profiling. Please note that
          this option only holds significance if the nsys profiler is used.
+
+    inference_data_grid : list
+        Grid dimensions used during inference. Typically, these are automatically
+        determined by DFT reference data, and this parameter does not need to
+        be set. Thus, this parameter mainly exists for debugging purposes.
+
+    use_mixed_precision :
+        If True, mixed precision computation (via AMP) will be used.
     """
 
     def __init__(self):
@@ -726,7 +782,6 @@ class ParametersRunning(ParametersBase):
         self.learning_rate = 10 ** (-5)
         self.learning_rate_embedding = 10 ** (-4)
         self.max_number_epochs = 100
-        self.verbosity = True
         self.mini_batch_size = 10
         self.snapshots_per_epoch = -1
 
@@ -975,6 +1030,15 @@ class ParametersHyperparameterOptimization(ParametersBase):
         not recommended because it is file based and can lead to errors;
         With a suitable timeout it can be used somewhat stable though and
         help in HPC settings.
+
+    acsd_points : int
+        Parameter of the ACSD HyperparamterOptimization scheme. Controls
+        the number of point-pairs which are used to compute the ACSD.
+        An array of acsd_points*acsd_points will be computed, i.e., if
+        acsd_points=100, 100 points will be drawn at random, and thereafter
+        each of these 100 points will be compared with a new, random set
+        of 100 points, leading to 10000 points in total for the calculation
+        of the ACSD.
     """
 
     def __init__(self):
@@ -1184,6 +1248,9 @@ class Parameters:
     manual_seed: int
         If not none, this value is used as manual seed for the neural networks.
         Can be used to make experiments comparable. Default: None.
+
+    datageneration : ParametersDataGeneration
+        Parameters used for data generation routines.
     """
 
     def __init__(self):

--- a/mala/common/parameters.py
+++ b/mala/common/parameters.py
@@ -320,11 +320,6 @@ class ParametersDescriptors(ParametersBase):
         bispectrum descriptors. Default value for jmax is 5, so default value
         for twojmax is 10.
 
-    lammps_compute_file : string
-        Bispectrum calculation: LAMMPS input file that is used to calculate the
-        Bispectrum descriptors. If this string is empty, the standard LAMMPS input
-        file found in this repository will be used (recommended).
-
     descriptors_contain_xyz : bool
         Legacy option. If True, it is assumed that the first three entries of
         the descriptor vector are the xyz coordinates and they are cut from the
@@ -348,11 +343,6 @@ class ParametersDescriptors(ParametersBase):
         correctly during inference based on model parameters. This parameter
         mainly exists for debugging purposes. If the atomic density is instead
         used for model training itself, this parameter needs to be set.
-
-    descriptor_type : str
-        Type of Descriptors used for model training. Supported are "Bispectrum"
-        and "AtomicDensity", although only the former is currently used for
-        published models.
 
     lammps_compute_file : str
         Path to a LAMMPS compute file for the bispectrum descriptor
@@ -750,13 +740,6 @@ class ParametersRunning(ParametersBase):
         If True, then upon creating logging files, these will be saved
         in a subfolder of logging_dir labelled with the starting date
         of the logging, to avoid having to change input scripts often.
-
-    inference_data_grid : list
-        List holding the grid to be used for inference in the form of
-        [x,y,z].
-
-    use_mixed_precision : bool
-        If True, mixed precision computation (via AMP) will be used.
 
     training_log_interval : int
         Determines how often detailed performance info is printed during

--- a/mala/common/parameters.py
+++ b/mala/common/parameters.py
@@ -781,9 +781,6 @@ class ParametersRunning(ParametersBase):
 
     dropout : float
         Dropout rate for positional encoding in transformer net.
-
-    training_log_interval : int
-        Number of data points after which metrics will be logged.
     """
 
     def __init__(self):

--- a/mala/common/physical_data.py
+++ b/mala/common/physical_data.py
@@ -29,7 +29,7 @@ class PhysicalData(ABC):
     Attributes
     ----------
     parameters : mala.Parameters
-        Internal copy of the MALA parameters object
+        Internal copy of the MALA parameters object.
 
     grid_dimensions : list
         List of the grid dimensions (x,y,z)
@@ -542,13 +542,21 @@ class PhysicalData(ABC):
             metadata will be read from this source. This metadata will then,
             depending on the class, be saved in the OpenPMD file.
 
-        local_offset  : int
+        local_offset  : list
+            [x,y,z] value from which to start writing the array.
 
-        local_reach  : int
+        local_reach  : list
+            [x,y,z] value until which to read the array.
 
         feature_from  : int
+            Value from which to start writing in the feature dimension. With
+            this parameter and feature_to, one can parallelize over the feature
+            dimension.
 
         feature_to : int
+            Value until which to write in the feature dimension. With
+            this parameter and feature_from, one can parallelize over the feature
+            dimension.
         """
         import openpmd_api as io
 

--- a/mala/common/physical_data.py
+++ b/mala/common/physical_data.py
@@ -12,10 +12,27 @@ from mala.version import __version__ as mala_version
 
 class PhysicalData(ABC):
     """
-    Base class for physical data.
+    Base class for volumetric physical data.
 
     Implements general framework to read and write such data to and from
-    files.
+    files. Volumetric data is assumed to exist on a 3D grid. As such it
+    either has the dimensions [x,y,z,f], where f is the feature dimension.
+    All loading functions within this class assume such a 4D array. Within
+    MALA, occasionally 2D arrays of dimension [x*y*z,f] are used and reshaped
+    accordingly.
+
+    Parameters
+    ----------
+    parameters : mala.Parameters
+        MALA Parameters object used to create this class.
+
+    Attributes
+    ----------
+    parameters : mala.Parameters
+        Internal copy of the MALA parameters object
+
+    grid_dimensions : list
+        List of the grid dimensions (x,y,z)
     """
 
     ##############################
@@ -85,6 +102,9 @@ class PhysicalData(ABC):
         array : np.ndarray
             If not None, the array to save the data into.
             The array has to be 4-dimensional.
+
+        reshape : bool
+            If True, the loaded 4D array will be reshaped into a 2D array.
 
         Returns
         -------
@@ -263,6 +283,14 @@ class PhysicalData(ABC):
 
         read_dtype : bool
             If True, the dtype is read alongside the dimensions.
+
+        Returns
+        -------
+        dimension_info : list or tuple
+            If read_dtype is False, then only a list containing the dimensions
+            of the saved array is returned. If read_dtype is True, a tuple
+            containing this list of dimensions and the dtype of the array will
+            be returned.
         """
         loaded_array = np.load(path, mmap_mode="r")
         if read_dtype:
@@ -286,6 +314,14 @@ class PhysicalData(ABC):
 
         read_dtype : bool
             If True, the dtype is read alongside the dimensions.
+
+        comm : MPI.Comm
+            An MPI communicator to be used for parallelized I/O
+
+        Returns
+        -------
+        dimension_info : list
+            A list containing the dimensions of the saved array.
         """
         if comm is None or comm.rank == 0:
             import openpmd_api as io
@@ -379,6 +415,22 @@ class PhysicalData(ABC):
 
         In order to provide this data, the numpy array can be replaced with an
         instance of the class SkipArrayWriting.
+
+        Parameters
+        ----------
+        dataset : openpmd_api.Dataset
+            OpenPMD Data set to eventually write to.
+
+        feature_size : int
+            Size of the feature dimension.
+
+        Attributes
+        ----------
+        dataset : mala.Parameters
+            Internal copy of the openPMD Data set to eventually write to.
+
+        feature_size : list
+            Internal copy of the size of the feature dimension.
         """
 
         # dataset has type openpmd_api.Dataset (not adding a type hint to avoid
@@ -408,7 +460,7 @@ class PhysicalData(ABC):
             the openPMD structure.
 
         additional_attributes : dict
-            Dict containing additional attributes to be saved.
+            Dictionary containing additional attributes to be saved.
 
         internal_iteration_number : int
             Internal OpenPMD iteration number. Ideally, this number should
@@ -489,6 +541,14 @@ class PhysicalData(ABC):
             If not None, and the selected class implements it, additional
             metadata will be read from this source. This metadata will then,
             depending on the class, be saved in the OpenPMD file.
+
+        local_offset  : int
+
+        local_reach  : int
+
+        feature_from  : int
+
+        feature_to : int
         """
         import openpmd_api as io
 

--- a/mala/common/physical_data.py
+++ b/mala/common/physical_data.py
@@ -29,7 +29,7 @@ class PhysicalData(ABC):
     Attributes
     ----------
     parameters : mala.Parameters
-        Internal copy of the MALA parameters object.
+        MALA parameters object.
 
     grid_dimensions : list
         List of the grid dimensions (x,y,z)
@@ -427,10 +427,10 @@ class PhysicalData(ABC):
         Attributes
         ----------
         dataset : mala.Parameters
-            Internal copy of the openPMD Data set to eventually write to.
+            OpenPMD Data set to eventually write to.
 
         feature_size : list
-            Internal copy of the size of the feature dimension.
+            Size of the feature dimension.
         """
 
         # dataset has type openpmd_api.Dataset (not adding a type hint to avoid

--- a/mala/datageneration/ofdft_initializer.py
+++ b/mala/datageneration/ofdft_initializer.py
@@ -32,11 +32,11 @@ class OFDFTInitializer:
 
     Attributes
     ----------
-    parameters : mala.Parameters
-        Internal copy of the MALA parameters object.
+    parameters : mala.mala.common.parameters.ParametersDataGeneration
+        MALA data generation parameters object.
 
     atoms : ase.Atoms
-        Internal copy of the initial atomic configuration for which an
+        Initial atomic configuration for which an
         equilibrated configuration is to be created.
 
     dftpy_configuration : dict

--- a/mala/datageneration/ofdft_initializer.py
+++ b/mala/datageneration/ofdft_initializer.py
@@ -22,12 +22,26 @@ class OFDFTInitializer:
 
     Parameters
     ----------
-    parameters : mala.common.parameters.Parameters
-        Parameters object used to create this instance.
+    parameters : mala.Parameters
+        MALA parameters object used to create this instance.
 
     atoms : ase.Atoms
         Initial atomic configuration for which an equilibrated configuration
         is to be created.
+
+
+    Attributes
+    ----------
+    parameters : mala.Parameters
+        Internal copy of the MALA parameters object.
+
+    atoms : ase.Atoms
+        Internal copy of the initial atomic configuration for which an
+        equilibrated configuration is to be created.
+
+    dftpy_configuration : dict
+        Dictionary containing the DFTpy configuration. Will partially be
+        populated via the MALA parameters object.
     """
 
     def __init__(self, parameters, atoms):
@@ -37,7 +51,7 @@ class OFDFTInitializer:
             "large changes."
         )
         self.atoms = atoms
-        self.params = parameters.datageneration
+        self.parameters = parameters.datageneration
 
         # Check that only one element is used in the atoms.
         number_of_elements = len(set([x.symbol for x in self.atoms]))
@@ -47,11 +61,13 @@ class OFDFTInitializer:
             )
         self.dftpy_configuration = DefaultOption()
 
-        self.dftpy_configuration["PATH"]["pppath"] = self.params.local_psp_path
+        self.dftpy_configuration["PATH"][
+            "pppath"
+        ] = self.parameters.local_psp_path
         self.dftpy_configuration["PP"][
             self.atoms[0].symbol
-        ] = self.params.local_psp_name
-        self.dftpy_configuration["OPT"]["method"] = self.params.ofdft_kedf
+        ] = self.parameters.local_psp_name
+        self.dftpy_configuration["OPT"]["method"] = self.parameters.ofdft_kedf
         self.dftpy_configuration["KEDF"]["kedf"] = "WT"
         self.dftpy_configuration["JOB"]["calctype"] = "Energy Force"
 
@@ -64,6 +80,11 @@ class OFDFTInitializer:
         logging_period : int
             If not None, a .log and .traj file will be filled with snapshot
             information every logging_period steps.
+
+        Returns
+        -------
+        equilibrated_configuration : ase.Atoms
+            Equilibrated atomic configuration.
         """
         # Set the DFTPy configuration.
         conf = OptionFormat(self.dftpy_configuration)
@@ -75,14 +96,14 @@ class OFDFTInitializer:
         # Create the initial velocities, and dynamics object.
         MaxwellBoltzmannDistribution(
             self.atoms,
-            temperature_K=self.params.ofdft_temperature,
+            temperature_K=self.parameters.ofdft_temperature,
             force_temp=True,
         )
         dyn = Langevin(
             self.atoms,
-            self.params.ofdft_timestep * units.fs,
-            temperature_K=self.params.ofdft_temperature,
-            friction=self.params.ofdft_friction,
+            self.parameters.ofdft_timestep * units.fs,
+            temperature_K=self.parameters.ofdft_temperature,
+            friction=self.parameters.ofdft_friction,
         )
 
         # If logging is desired, do the logging.
@@ -105,5 +126,5 @@ class OFDFTInitializer:
 
         # Let the OF-DFT-MD run.
         ase.io.write("POSCAR_initial", self.atoms, "vasp")
-        dyn.run(self.params.ofdft_number_of_timesteps)
+        dyn.run(self.parameters.ofdft_number_of_timesteps)
         ase.io.write("POSCAR_equilibrated", self.atoms, "vasp")

--- a/mala/datageneration/trajectory_analyzer.py
+++ b/mala/datageneration/trajectory_analyzer.py
@@ -29,6 +29,19 @@ class TrajectoryAnalyzer:
     target_calculator : mala.targets.target.Target
         A target calculator to calculate e.g. the RDF. If None is provided,
         one will be generated ad-hoc (recommended).
+
+    temperatures : string or numpy.ndarray
+        Array holding the temperatures for the trajectory or path to numpy
+        file containing temperatures.
+
+    target_temperature : float
+        Target temperature for equilibration.
+
+    malada_compatability : bool
+        If True, twice the radius set by the minimum imaging convention (MIC)
+        will be used for RDF calculation. This is generally discouraged,
+        but some older malada calculations have been performed with it, so
+        this parameter provides reproducibility.
     """
 
     def __init__(

--- a/mala/datageneration/trajectory_analyzer.py
+++ b/mala/datageneration/trajectory_analyzer.py
@@ -42,6 +42,34 @@ class TrajectoryAnalyzer:
         will be used for RDF calculation. This is generally discouraged,
         but some older malada calculations have been performed with it, so
         this parameter provides reproducibility.
+
+    Attributes
+    ----------
+    parameters : mala.common.parameters.ParametersDataGeneration
+        MALA data generation parameters.
+
+    average_distance_equilibrated : float
+        Distance threshold for determination of first equilibrated snapshot.
+
+    distance_metrics_denoised : numpy.ndarray
+        RDF based distance metrics used for equilibration analysis.
+
+    distances_realspace : numpy.ndarray
+        Realspace distance metrics used to sample snapshots.
+
+    first_considered_snapshot : int
+        First snapshot to be considered during equilibration analysis (i.e.,
+        after pruning).
+
+    first_snapshot : int
+        First snapshot that can be considered to be equilibrated.
+
+    last_considered_snapshot : int
+        Last snapshot to be considered during equilibration analysis (i.e.,
+        after pruning).
+
+    target_calculator : mala.targets.target.Target
+        Target calculator used for computing RDFs.
     """
 
     def __init__(
@@ -59,7 +87,7 @@ class TrajectoryAnalyzer:
             "large changes."
         )
 
-        self.params: ParametersDataGeneration = parameters.datageneration
+        self.parameters: ParametersDataGeneration = parameters.datageneration
 
         # If needed, read the trajectory
         self.trajectory = None
@@ -71,12 +99,12 @@ class TrajectoryAnalyzer:
             raise Exception("Incompatible trajectory format provided.")
 
         # If needed, read the temperature files
-        self.temperatures = None
+        self._temperatures = None
         if temperatures is not None:
             if isinstance(temperatures, np.ndarray):
-                self.temperatures = temperatures
+                self._temperatures = temperatures
             elif isinstance(temperatures, str):
-                self.temperatures = np.load(temperatures)
+                self._temperatures = np.load(temperatures)
             else:
                 raise Exception("Incompatible temperature format provided.")
 
@@ -89,7 +117,7 @@ class TrajectoryAnalyzer:
             self.target_calculator.temperature = target_temperature
 
         # Initialize variables.
-        self.distance_metrics = []
+        self._distance_metrics = []
         self.distance_metrics_denoised = []
         self.average_distance_equilibrated = None
         self.__saved_rdf = None
@@ -163,11 +191,11 @@ class TrajectoryAnalyzer:
         # First, we ned to calculate the reduced metrics for the trajectory.
         # For this, we calculate the distance between all the snapshots
         # and the last one.
-        self.distance_metrics = []
+        self._distance_metrics = []
         if equilibrated_snapshot is None:
             equilibrated_snapshot = self.trajectory[-1]
         for idx, step in enumerate(self.trajectory):
-            self.distance_metrics.append(
+            self._distance_metrics.append(
                 self._calculate_distance_between_snapshots(
                     equilibrated_snapshot,
                     step,
@@ -178,16 +206,16 @@ class TrajectoryAnalyzer:
             )
 
         # Now, we denoise the distance metrics.
-        self.distance_metrics_denoised = self.__denoise(self.distance_metrics)
+        self.distance_metrics_denoised = self.__denoise(self._distance_metrics)
 
         # Which snapshots are considered depends on how we denoise the
         # distance metrics.
         self.first_considered_snapshot = (
-            self.params.trajectory_analysis_denoising_width
+            self.parameters.trajectory_analysis_denoising_width
         )
         self.last_considered_snapshot = (
             np.shape(self.distance_metrics_denoised)[0]
-            - self.params.trajectory_analysis_denoising_width
+            - self.parameters.trajectory_analysis_denoising_width
         )
         considered_length = (
             self.last_considered_snapshot - self.first_considered_snapshot
@@ -202,7 +230,7 @@ class TrajectoryAnalyzer:
                 self.distance_metrics_denoised[
                     considered_length
                     - int(
-                        self.params.trajectory_analysis_estimated_equilibrium
+                        self.parameters.trajectory_analysis_estimated_equilibrium
                         * considered_length
                     ) : self.last_considered_snapshot
                 ]
@@ -225,7 +253,7 @@ class TrajectoryAnalyzer:
                     is_below = False
                 if (
                     counter
-                    == self.params.trajectory_analysis_below_average_counter
+                    == self.parameters.trajectory_analysis_below_average_counter
                 ):
                     first_snapshot = idx
                     break
@@ -255,10 +283,12 @@ class TrajectoryAnalyzer:
             to each other to a degree that suggests temporal neighborhood.
 
         """
-        if self.params.trajectory_analysis_correlation_metric_cutoff < 0:
+        if self.parameters.trajectory_analysis_correlation_metric_cutoff < 0:
             return self._analyze_distance_metric(self.trajectory)
         else:
-            return self.params.trajectory_analysis_correlation_metric_cutoff
+            return (
+                self.parameters.trajectory_analysis_correlation_metric_cutoff
+            )
 
     def get_uncorrelated_snapshots(self, filename_uncorrelated_snapshots):
         """
@@ -278,7 +308,8 @@ class TrajectoryAnalyzer:
             filename_uncorrelated_snapshots
         ).split(".")[0]
         allowed_temp_diff_K = (
-            self.params.trajectory_analysis_temperature_tolerance_percent / 100
+            self.parameters.trajectory_analysis_temperature_tolerance_percent
+            / 100
         ) * self.target_calculator.temperature
         current_snapshot = self.first_snapshot
         begin_snapshot = self.first_snapshot + 1
@@ -288,9 +319,9 @@ class TrajectoryAnalyzer:
         for i in range(begin_snapshot, end_snapshot):
             if self.__check_if_snapshot_is_valid(
                 self.trajectory[i],
-                self.temperatures[i],
+                self._temperatures[i],
                 self.trajectory[current_snapshot],
-                self.temperatures[current_snapshot],
+                self._temperatures[current_snapshot],
                 self.snapshot_correlation_cutoff,
                 allowed_temp_diff_K,
             ):
@@ -329,7 +360,7 @@ class TrajectoryAnalyzer:
             + self.first_snapshot
         )
         width = int(
-            self.params.trajectory_analysis_estimated_equilibrium
+            self.parameters.trajectory_analysis_estimated_equilibrium
             * np.shape(self.distance_metrics_denoised)[0]
         )
         self.distances_realspace = []
@@ -416,8 +447,8 @@ class TrajectoryAnalyzer:
     def __denoise(self, signal):
         denoised_signal = np.convolve(
             signal,
-            np.ones(self.params.trajectory_analysis_denoising_width)
-            / self.params.trajectory_analysis_denoising_width,
+            np.ones(self.parameters.trajectory_analysis_denoising_width)
+            / self.parameters.trajectory_analysis_denoising_width,
             mode="same",
         )
         return denoised_signal

--- a/mala/datageneration/trajectory_analyzer.py
+++ b/mala/datageneration/trajectory_analyzer.py
@@ -61,9 +61,6 @@ class TrajectoryAnalyzer:
         First snapshot to be considered during equilibration analysis (i.e.,
         after pruning).
 
-    first_snapshot : int
-        First snapshot that can be considered to be equilibrated.
-
     last_considered_snapshot : int
         Last snapshot to be considered during equilibration analysis (i.e.,
         after pruning).

--- a/mala/datahandling/data_converter.py
+++ b/mala/datahandling/data_converter.py
@@ -44,8 +44,12 @@ class DataConverter:
     target_calculator : mala.targets.target.Target
         Target calculator used for parsing/converting target data.
 
-    parameters : mala.Parama
-    parameters_full
+    parameters : mala.common.parameters.ParametersData
+        MALA data handling parameters object.
+
+    parameters_full : mala.common.parameters.Parameters
+        MALA parameters object. The full object is necessary for some data
+        handling tasks.
     """
 
     def __init__(
@@ -502,9 +506,6 @@ class DataConverter:
 
         output_path : string
             If not None, outputs will be saved in this file.
-
-        return_data : bool
-            If True, inputs and outputs will be returned directly.
 
         target_calculator_kwargs : dict
             Dictionary with additional keyword arguments for the calculation

--- a/mala/datahandling/data_converter.py
+++ b/mala/datahandling/data_converter.py
@@ -43,6 +43,9 @@ class DataConverter:
 
     target_calculator : mala.targets.target.Target
         Target calculator used for parsing/converting target data.
+
+    parameters : mala.Parama
+    parameters_full
     """
 
     def __init__(
@@ -69,9 +72,9 @@ class DataConverter:
         self.__snapshot_units = []
 
         # Keep track of what has to be done by this data converter.
-        self.process_descriptors = False
-        self.process_targets = False
-        self.process_additional_info = False
+        self.__process_descriptors = False
+        self.__process_targets = False
+        self.__process_additional_info = False
 
     def add_snapshot(
         self,
@@ -143,7 +146,7 @@ class DataConverter:
                 )
             if descriptor_input_type not in descriptor_input_types:
                 raise Exception("Cannot process this type of descriptor data.")
-            self.process_descriptors = True
+            self.__process_descriptors = True
 
         if target_input_type is not None:
             if target_input_path is None:
@@ -152,7 +155,7 @@ class DataConverter:
                 )
             if target_input_type not in target_input_types:
                 raise Exception("Cannot process this type of target data.")
-            self.process_targets = True
+            self.__process_targets = True
 
         if additional_info_input_type is not None:
             metadata_input_type = additional_info_input_type
@@ -165,7 +168,7 @@ class DataConverter:
                 raise Exception(
                     "Cannot process this type of additional info data."
                 )
-            self.process_additional_info = True
+            self.__process_additional_info = True
 
             metadata_input_path = additional_info_input_path
 
@@ -299,19 +302,19 @@ class DataConverter:
             target_save_path = complete_save_path
             additional_info_save_path = complete_save_path
         else:
-            if self.process_targets is True and target_save_path is None:
+            if self.__process_targets is True and target_save_path is None:
                 raise Exception(
                     "No target path specified, cannot process data."
                 )
             if (
-                self.process_descriptors is True
+                self.__process_descriptors is True
                 and descriptor_save_path is None
             ):
                 raise Exception(
                     "No descriptor path specified, cannot process data."
                 )
             if (
-                self.process_additional_info is True
+                self.__process_additional_info is True
                 and additional_info_save_path is None
             ):
                 raise Exception(
@@ -323,7 +326,7 @@ class DataConverter:
             snapshot_name = naming_scheme
             series_name = snapshot_name.replace("*", str("%01T"))
 
-            if self.process_descriptors:
+            if self.__process_descriptors:
                 if self.parameters._configuration["mpi"]:
                     input_series = io.Series(
                         os.path.join(
@@ -351,7 +354,7 @@ class DataConverter:
                 input_series.set_software(name="MALA", version="x.x.x")
                 input_series.author = "..."
 
-            if self.process_targets:
+            if self.__process_targets:
                 if self.parameters._configuration["mpi"]:
                     output_series = io.Series(
                         os.path.join(
@@ -386,7 +389,7 @@ class DataConverter:
             snapshot_name = snapshot_name.replace("*", str(snapshot_number))
 
             # Create the paths as needed.
-            if self.process_additional_info:
+            if self.__process_additional_info:
                 info_path = os.path.join(
                     additional_info_save_path, snapshot_name + ".info.json"
                 )
@@ -397,7 +400,7 @@ class DataConverter:
 
             if file_ending == "npy":
                 # Create the actual paths, if needed.
-                if self.process_descriptors:
+                if self.__process_descriptors:
                     descriptor_path = os.path.join(
                         descriptor_save_path,
                         snapshot_name + ".in." + file_ending,
@@ -406,7 +409,7 @@ class DataConverter:
                     descriptor_path = None
 
                 memmap = None
-                if self.process_targets:
+                if self.__process_targets:
                     target_path = os.path.join(
                         target_save_path,
                         snapshot_name + ".out." + file_ending,
@@ -425,13 +428,13 @@ class DataConverter:
                 descriptor_path = None
                 target_path = None
                 memmap = None
-                if self.process_descriptors:
+                if self.__process_descriptors:
                     input_iteration = input_series.write_iterations()[
                         i + starts_at
                     ]
                     input_iteration.dt = i + starts_at
                     input_iteration.time = 0
-                if self.process_targets:
+                if self.__process_targets:
                     output_iteration = output_series.write_iterations()[
                         i + starts_at
                     ]
@@ -460,9 +463,9 @@ class DataConverter:
 
         # Properly close series
         if file_ending != "npy":
-            if self.process_descriptors:
+            if self.__process_descriptors:
                 del input_series
-            if self.process_targets:
+            if self.__process_targets:
                 del output_series
 
     def __convert_single_snapshot(
@@ -636,10 +639,8 @@ class DataConverter:
                         snapshot["output"], units=original_units["output"]
                     )
                 elif description["output"] == "numpy":
-                    tmp_output = (
-                        self.target_calculator.read_from_numpy_file(
-                            snapshot["output"], units=original_units["output"]
-                        )
+                    tmp_output = self.target_calculator.read_from_numpy_file(
+                        snapshot["output"], units=original_units["output"]
                     )
 
                 elif description["output"] is None:
@@ -687,10 +688,8 @@ class DataConverter:
                         snapshot["output"], units=original_units["output"]
                     )
                 elif description["output"] == "numpy":
-                    tmp_output = (
-                        self.target_calculator.read_from_numpy_file(
-                            snapshot["output"]
-                        )
+                    tmp_output = self.target_calculator.read_from_numpy_file(
+                        snapshot["output"]
                     )
 
                 elif description["output"] is None:

--- a/mala/datahandling/data_handler.py
+++ b/mala/datahandling/data_handler.py
@@ -569,7 +569,7 @@ class DataHandler(DataHandlerBase):
             raise Exception("Unknown data type detected.")
 
         # Extracting all the information pertaining to the data set.
-        array = function + "_data_" + data_type
+        array = "_" + function + "_data_" + data_type
         if data_type == "inputs":
             calculator = self.descriptor_calculator
         else:

--- a/mala/datahandling/data_handler.py
+++ b/mala/datahandling/data_handler.py
@@ -107,14 +107,14 @@ class DataHandler(DataHandlerBase):
         if self.input_data_scaler is None:
             self.input_data_scaler = DataScaler(
                 self.parameters.input_rescaling_type,
-                use_ddp=self.use_ddp,
+                use_ddp=self._use_ddp,
             )
 
         self.output_data_scaler = output_data_scaler
         if self.output_data_scaler is None:
             self.output_data_scaler = DataScaler(
                 self.parameters.output_rescaling_type,
-                use_ddp=self.use_ddp,
+                use_ddp=self._use_ddp,
             )
 
         # Actual data points in the different categories.
@@ -677,7 +677,7 @@ class DataHandler(DataHandlerBase):
                     self.output_data_scaler,
                     self.descriptor_calculator,
                     self.target_calculator,
-                    self.use_ddp,
+                    self._use_ddp,
                     self.parameters._configuration["device"],
                 )
             )
@@ -689,7 +689,7 @@ class DataHandler(DataHandlerBase):
                     self.output_data_scaler,
                     self.descriptor_calculator,
                     self.target_calculator,
-                    self.use_ddp,
+                    self._use_ddp,
                     self.parameters._configuration["device"],
                 )
             )
@@ -703,7 +703,7 @@ class DataHandler(DataHandlerBase):
                         self.output_data_scaler,
                         self.descriptor_calculator,
                         self.target_calculator,
-                        self.use_ddp,
+                        self._use_ddp,
                         self.parameters._configuration["device"],
                         input_requires_grad=True,
                     )
@@ -747,7 +747,7 @@ class DataHandler(DataHandlerBase):
                             self.output_data_scaler,
                             self.descriptor_calculator,
                             self.target_calculator,
-                            self.use_ddp,
+                            self._use_ddp,
                         )
                     )
                 if snapshot.snapshot_function == "va":
@@ -761,7 +761,7 @@ class DataHandler(DataHandlerBase):
                             self.output_data_scaler,
                             self.descriptor_calculator,
                             self.target_calculator,
-                            self.use_ddp,
+                            self._use_ddp,
                         )
                     )
                 if snapshot.snapshot_function == "te":
@@ -775,7 +775,7 @@ class DataHandler(DataHandlerBase):
                             self.output_data_scaler,
                             self.descriptor_calculator,
                             self.target_calculator,
-                            self.use_ddp,
+                            self._use_ddp,
                             input_requires_grad=True,
                         )
                     )

--- a/mala/datahandling/data_handler_base.py
+++ b/mala/datahandling/data_handler_base.py
@@ -28,6 +28,20 @@ class DataHandlerBase(ABC):
     target_calculator : mala.targets.target.Target
         Used to do unit conversion on output data. If None, then one will
         be created by this class.
+
+    Attributes
+    ----------
+    descriptor_calculator
+        Used to do unit conversion on input data.
+
+    nr_snapshots : int
+        Number of snapshots loaded.
+
+    parameters : mala.common.parameters.ParametersData
+        MALA data handling parameters.
+
+    target_calculator
+        Used to do unit conversion on output data.
     """
 
     def __init__(
@@ -37,7 +51,7 @@ class DataHandlerBase(ABC):
         descriptor_calculator=None,
     ):
         self.parameters: ParametersData = parameters.data
-        self.use_ddp = parameters.use_ddp
+        self._use_ddp = parameters.use_ddp
 
         # Calculators used to parse data from compatible files.
         self.target_calculator = target_calculator

--- a/mala/datahandling/data_scaler.py
+++ b/mala/datahandling/data_scaler.py
@@ -32,45 +32,50 @@ class DataScaler:
     use_ddp : bool
         If True, the DataScaler will use ddp to check that data is
         only saved on the root process in parallel execution.
+
+    Attributes
+    ----------
+    cantransform : bool
+        If True, this scaler is set up to perform scaling.
     """
 
     def __init__(self, typestring, use_ddp=False):
-        self.use_ddp = use_ddp
-        self.typestring = typestring
-        self.scale_standard = False
-        self.scale_normal = False
-        self.feature_wise = False
+        self._use_ddp = use_ddp
+        self._typestring = typestring
+        self._scale_standard = False
+        self._scale_normal = False
+        self._feature_wise = False
         self.cantransform = False
         self.__parse_typestring()
 
-        self.means = torch.empty(0)
-        self.stds = torch.empty(0)
-        self.maxs = torch.empty(0)
-        self.mins = torch.empty(0)
-        self.total_mean = torch.tensor(0)
-        self.total_std = torch.tensor(0)
-        self.total_max = torch.tensor(float("-inf"))
-        self.total_min = torch.tensor(float("inf"))
+        self._means = torch.empty(0)
+        self._stds = torch.empty(0)
+        self._maxs = torch.empty(0)
+        self._mins = torch.empty(0)
+        self._total_mean = torch.tensor(0)
+        self._total_std = torch.tensor(0)
+        self._total_max = torch.tensor(float("-inf"))
+        self._total_min = torch.tensor(float("inf"))
 
-        self.total_data_count = 0
+        self._total_data_count = 0
 
     def __parse_typestring(self):
         """Parse the typestring to class attributes."""
-        self.scale_standard = False
-        self.scale_normal = False
-        self.feature_wise = False
+        self._scale_standard = False
+        self._scale_normal = False
+        self._feature_wise = False
 
-        if "standard" in self.typestring:
-            self.scale_standard = True
-        if "normal" in self.typestring:
-            self.scale_normal = True
-        if "feature-wise" in self.typestring:
-            self.feature_wise = True
-        if self.scale_standard is False and self.scale_normal is False:
+        if "standard" in self._typestring:
+            self._scale_standard = True
+        if "normal" in self._typestring:
+            self._scale_normal = True
+        if "feature-wise" in self._typestring:
+            self._feature_wise = True
+        if self._scale_standard is False and self._scale_normal is False:
             printout("No data rescaling will be performed.", min_verbosity=1)
             self.cantransform = True
             return
-        if self.scale_standard is True and self.scale_normal is True:
+        if self._scale_standard is True and self._scale_normal is True:
             raise Exception("Invalid input data rescaling.")
 
     def start_incremental_fitting(self):
@@ -79,7 +84,7 @@ class DataScaler:
 
         This is necessary for lazy loading.
         """
-        self.total_data_count = 0
+        self._total_data_count = 0
 
     def incremental_fit(self, unscaled):
         """
@@ -93,71 +98,71 @@ class DataScaler:
             Data that is to be added to the fit.
 
         """
-        if self.scale_standard is False and self.scale_normal is False:
+        if self._scale_standard is False and self._scale_normal is False:
             return
         else:
             with torch.no_grad():
-                if self.feature_wise:
+                if self._feature_wise:
 
                     ##########################
                     # Feature-wise-scaling
                     ##########################
 
-                    if self.scale_standard:
+                    if self._scale_standard:
                         new_mean = torch.mean(unscaled, 0, keepdim=True)
                         new_std = torch.std(unscaled, 0, keepdim=True)
 
                         current_data_count = list(unscaled.size())[0]
 
-                        old_mean = self.means
-                        old_std = self.stds
+                        old_mean = self._means
+                        old_std = self._stds
 
-                        if list(self.means.size())[0] > 0:
-                            self.means = (
-                                self.total_data_count
-                                / (self.total_data_count + current_data_count)
+                        if list(self._means.size())[0] > 0:
+                            self._means = (
+                                self._total_data_count
+                                / (self._total_data_count + current_data_count)
                                 * old_mean
                                 + current_data_count
-                                / (self.total_data_count + current_data_count)
+                                / (self._total_data_count + current_data_count)
                                 * new_mean
                             )
                         else:
-                            self.means = new_mean
-                        if list(self.stds.size())[0] > 0:
-                            self.stds = (
-                                self.total_data_count
-                                / (self.total_data_count + current_data_count)
+                            self._means = new_mean
+                        if list(self._stds.size())[0] > 0:
+                            self._stds = (
+                                self._total_data_count
+                                / (self._total_data_count + current_data_count)
                                 * old_std**2
                                 + current_data_count
-                                / (self.total_data_count + current_data_count)
+                                / (self._total_data_count + current_data_count)
                                 * new_std**2
-                                + (self.total_data_count * current_data_count)
-                                / (self.total_data_count + current_data_count)
+                                + (self._total_data_count * current_data_count)
+                                / (self._total_data_count + current_data_count)
                                 ** 2
                                 * (old_mean - new_mean) ** 2
                             )
 
-                            self.stds = torch.sqrt(self.stds)
+                            self._stds = torch.sqrt(self._stds)
                         else:
-                            self.stds = new_std
-                        self.total_data_count += current_data_count
+                            self._stds = new_std
+                        self._total_data_count += current_data_count
 
-                    if self.scale_normal:
+                    if self._scale_normal:
                         new_maxs = torch.max(unscaled, 0, keepdim=True)
-                        if list(self.maxs.size())[0] > 0:
+                        if list(self._maxs.size())[0] > 0:
                             for i in range(list(new_maxs.values.size())[1]):
-                                if new_maxs.values[0, i] > self.maxs[i]:
-                                    self.maxs[i] = new_maxs.values[0, i]
+                                if new_maxs.values[0, i] > self._maxs[i]:
+                                    self._maxs[i] = new_maxs.values[0, i]
                         else:
-                            self.maxs = new_maxs.values[0, :]
+                            self._maxs = new_maxs.values[0, :]
 
                         new_mins = torch.min(unscaled, 0, keepdim=True)
-                        if list(self.mins.size())[0] > 0:
+                        if list(self._mins.size())[0] > 0:
                             for i in range(list(new_mins.values.size())[1]):
-                                if new_mins.values[0, i] < self.mins[i]:
-                                    self.mins[i] = new_mins.values[0, i]
+                                if new_mins.values[0, i] < self._mins[i]:
+                                    self._mins[i] = new_mins.values[0, i]
                         else:
-                            self.mins = new_mins.values[0, :]
+                            self._mins = new_mins.values[0, :]
 
                 else:
 
@@ -165,7 +170,7 @@ class DataScaler:
                     # Total scaling
                     ##########################
 
-                    if self.scale_standard:
+                    if self._scale_standard:
                         current_data_count = (
                             list(unscaled.size())[0] * list(unscaled.size())[1]
                         )
@@ -173,15 +178,15 @@ class DataScaler:
                         new_mean = torch.mean(unscaled)
                         new_std = torch.std(unscaled)
 
-                        old_mean = self.total_mean
-                        old_std = self.total_std
+                        old_mean = self._total_mean
+                        old_std = self._total_std
 
-                        self.total_mean = (
-                            self.total_data_count
-                            / (self.total_data_count + current_data_count)
+                        self._total_mean = (
+                            self._total_data_count
+                            / (self._total_data_count + current_data_count)
                             * old_mean
                             + current_data_count
-                            / (self.total_data_count + current_data_count)
+                            / (self._total_data_count + current_data_count)
                             * new_mean
                         )
 
@@ -190,29 +195,30 @@ class DataScaler:
                         # results.
                         # Maybe we should check it at some point .
                         # I think it is merely an issue of numerical accuracy.
-                        self.total_std = (
-                            self.total_data_count
-                            / (self.total_data_count + current_data_count)
+                        self._total_std = (
+                            self._total_data_count
+                            / (self._total_data_count + current_data_count)
                             * old_std**2
                             + current_data_count
-                            / (self.total_data_count + current_data_count)
+                            / (self._total_data_count + current_data_count)
                             * new_std**2
-                            + (self.total_data_count * current_data_count)
-                            / (self.total_data_count + current_data_count) ** 2
+                            + (self._total_data_count * current_data_count)
+                            / (self._total_data_count + current_data_count)
+                            ** 2
                             * (old_mean - new_mean) ** 2
                         )
 
-                        self.total_std = torch.sqrt(self.total_std)
-                        self.total_data_count += current_data_count
+                        self._total_std = torch.sqrt(self._total_std)
+                        self._total_data_count += current_data_count
 
-                    if self.scale_normal:
+                    if self._scale_normal:
                         new_max = torch.max(unscaled)
-                        if new_max > self.total_max:
-                            self.total_max = new_max
+                        if new_max > self._total_max:
+                            self._total_max = new_max
 
                         new_min = torch.min(unscaled)
-                        if new_min < self.total_min:
-                            self.total_min = new_min
+                        if new_min < self._total_min:
+                            self._total_min = new_min
 
     def finish_incremental_fitting(self):
         """
@@ -232,23 +238,27 @@ class DataScaler:
             Data that on which the scaling will be calculated.
 
         """
-        if self.scale_standard is False and self.scale_normal is False:
+        if self._scale_standard is False and self._scale_normal is False:
             return
         else:
             with torch.no_grad():
-                if self.feature_wise:
+                if self._feature_wise:
 
                     ##########################
                     # Feature-wise-scaling
                     ##########################
 
-                    if self.scale_standard:
-                        self.means = torch.mean(unscaled, 0, keepdim=True)
-                        self.stds = torch.std(unscaled, 0, keepdim=True)
+                    if self._scale_standard:
+                        self._means = torch.mean(unscaled, 0, keepdim=True)
+                        self._stds = torch.std(unscaled, 0, keepdim=True)
 
-                    if self.scale_normal:
-                        self.maxs = torch.max(unscaled, 0, keepdim=True).values
-                        self.mins = torch.min(unscaled, 0, keepdim=True).values
+                    if self._scale_normal:
+                        self._maxs = torch.max(
+                            unscaled, 0, keepdim=True
+                        ).values
+                        self._mins = torch.min(
+                            unscaled, 0, keepdim=True
+                        ).values
 
                 else:
 
@@ -256,13 +266,13 @@ class DataScaler:
                     # Total scaling
                     ##########################
 
-                    if self.scale_standard:
-                        self.total_mean = torch.mean(unscaled)
-                        self.total_std = torch.std(unscaled)
+                    if self._scale_standard:
+                        self._total_mean = torch.mean(unscaled)
+                        self._total_std = torch.std(unscaled)
 
-                    if self.scale_normal:
-                        self.total_max = torch.max(unscaled)
-                        self.total_min = torch.min(unscaled)
+                    if self._scale_normal:
+                        self._total_max = torch.max(unscaled)
+                        self._total_min = torch.min(unscaled)
 
         self.cantransform = True
 
@@ -284,7 +294,7 @@ class DataScaler:
             Scaled data.
         """
         # First we need to find out if we even have to do anything.
-        if self.scale_standard is False and self.scale_normal is False:
+        if self._scale_standard is False and self._scale_normal is False:
             pass
 
         elif self.cantransform is False:
@@ -296,19 +306,19 @@ class DataScaler:
         # Perform the actual scaling, but use no_grad to make sure
         # that the next couple of iterations stay untracked.
         with torch.no_grad():
-            if self.feature_wise:
+            if self._feature_wise:
 
                 ##########################
                 # Feature-wise-scaling
                 ##########################
 
-                if self.scale_standard:
-                    unscaled -= self.means
-                    unscaled /= self.stds
+                if self._scale_standard:
+                    unscaled -= self._means
+                    unscaled /= self._stds
 
-                if self.scale_normal:
-                    unscaled -= self.mins
-                    unscaled /= self.maxs - self.mins
+                if self._scale_normal:
+                    unscaled -= self._mins
+                    unscaled /= self._maxs - self._mins
 
             else:
 
@@ -316,13 +326,13 @@ class DataScaler:
                 # Total scaling
                 ##########################
 
-                if self.scale_standard:
-                    unscaled -= self.total_mean
-                    unscaled /= self.total_std
+                if self._scale_standard:
+                    unscaled -= self._total_mean
+                    unscaled /= self._total_std
 
-                if self.scale_normal:
-                    unscaled -= self.total_min
-                    unscaled /= self.total_max - self.total_min
+                if self._scale_normal:
+                    unscaled -= self._total_min
+                    unscaled /= self._total_max - self._total_min
 
     def inverse_transform(self, scaled, as_numpy=False):
         """
@@ -346,7 +356,7 @@ class DataScaler:
 
         """
         # First we need to find out if we even have to do anything.
-        if self.scale_standard is False and self.scale_normal is False:
+        if self._scale_standard is False and self._scale_normal is False:
             unscaled = scaled
 
         else:
@@ -359,19 +369,19 @@ class DataScaler:
             # Perform the actual scaling, but use no_grad to make sure
             # that the next couple of iterations stay untracked.
             with torch.no_grad():
-                if self.feature_wise:
+                if self._feature_wise:
 
                     ##########################
                     # Feature-wise-scaling
                     ##########################
 
-                    if self.scale_standard:
-                        unscaled = (scaled * self.stds) + self.means
+                    if self._scale_standard:
+                        unscaled = (scaled * self._stds) + self._means
 
-                    if self.scale_normal:
+                    if self._scale_normal:
                         unscaled = (
-                            scaled * (self.maxs - self.mins)
-                        ) + self.mins
+                            scaled * (self._maxs - self._mins)
+                        ) + self._mins
 
                 else:
 
@@ -379,13 +389,15 @@ class DataScaler:
                     # Total scaling
                     ##########################
 
-                    if self.scale_standard:
-                        unscaled = (scaled * self.total_std) + self.total_mean
-
-                    if self.scale_normal:
+                    if self._scale_standard:
                         unscaled = (
-                            scaled * (self.total_max - self.total_min)
-                        ) + self.total_min
+                            scaled * self._total_std
+                        ) + self._total_mean
+
+                    if self._scale_normal:
+                        unscaled = (
+                            scaled * (self._total_max - self._total_min)
+                        ) + self._total_min
         #
         if as_numpy:
             return unscaled.detach().numpy().astype(np.float64)
@@ -405,7 +417,7 @@ class DataScaler:
             File format which will be used for saving.
         """
         # If we use ddp, only save the network on root.
-        if self.use_ddp:
+        if self._use_ddp:
             if dist.get_rank() != 0:
                 return
         if save_format == "pickle":

--- a/mala/datahandling/data_scaler.py
+++ b/mala/datahandling/data_scaler.py
@@ -65,7 +65,7 @@ class DataScaler:
     mins : torch.Tensor
         (Managed internally, not set to private due to legacy issues)
 
-    scale_normal : bool
+    scale_minmax : bool
         (Managed internally, not set to private due to legacy issues)
 
     scale_standard : bool

--- a/mala/datahandling/data_shuffler.py
+++ b/mala/datahandling/data_shuffler.py
@@ -53,7 +53,7 @@ class DataShuffler(DataHandlerBase):
             self.descriptor_calculator.parameters.descriptors_contain_xyz = (
                 False
             )
-        self.data_points_to_remove = None
+        self._data_points_to_remove = None
 
     def add_snapshot(
         self,
@@ -135,8 +135,8 @@ class DataShuffler(DataHandlerBase):
             # then we have to trim the original snapshots to size
             # the indicies to be removed are selected at random
             if (
-                self.data_points_to_remove is not None
-                and np.sum(self.data_points_to_remove) > 0
+                self._data_points_to_remove is not None
+                and np.sum(self._data_points_to_remove) > 0
             ):
                 if self.parameters.shuffling_seed is not None:
                     np.random.seed(idx * self.parameters.shuffling_seed)
@@ -155,7 +155,7 @@ class DataShuffler(DataHandlerBase):
 
                 indices = np.random.choice(
                     ngrid,
-                    size=ngrid - self.data_points_to_remove[idx],
+                    size=ngrid - self._data_points_to_remove[idx],
                 )
 
                 descriptor_data[idx] = current_descriptor[indices]
@@ -548,7 +548,7 @@ class DataShuffler(DataHandlerBase):
             ]
         )
         number_of_data_points = np.sum(snapshot_size_list)
-        self.data_points_to_remove = None
+        self._data_points_to_remove = None
         if number_of_shuffled_snapshots is None:
             number_of_shuffled_snapshots = self.nr_snapshots
 
@@ -584,13 +584,13 @@ class DataShuffler(DataHandlerBase):
                 np.sum(shuffled_gridsizes) * number_of_shuffled_snapshots
             )
 
-        self.data_points_to_remove = []
+        self._data_points_to_remove = []
         for i in range(0, self.nr_snapshots):
-            self.data_points_to_remove.append(
+            self._data_points_to_remove.append(
                 snapshot_size_list[i]
                 - shuffled_gridsizes[i] * number_of_shuffled_snapshots
             )
-        tot_points_missing = sum(self.data_points_to_remove)
+        tot_points_missing = sum(self._data_points_to_remove)
 
         if tot_points_missing > 0:
             printout(

--- a/mala/datahandling/fast_tensor_dataset.py
+++ b/mala/datahandling/fast_tensor_dataset.py
@@ -26,7 +26,6 @@ class FastTensorDataset(torch.utils.data.Dataset):
     """
 
     def __init__(self, batch_size, *tensors):
-        """ """
         super(FastTensorDataset).__init__()
         self.batch_size = batch_size
         self._tensors = tensors

--- a/mala/datahandling/fast_tensor_dataset.py
+++ b/mala/datahandling/fast_tensor_dataset.py
@@ -10,15 +10,29 @@ class FastTensorDataset(torch.utils.data.Dataset):
 
     This version of TensorDataset gathers data using a single call
     within  __getitem__. A bit more tricky to manage but is faster still.
+
+    Parameters
+    ----------
+    batch_size : int
+        Batch size to be used with this data set.
+
+    tensors : object
+        Torch tensors for this data set.
+
+    Attributes
+    ----------
+    batch_size : int
+        Batch size to be used with this data set.
     """
 
     def __init__(self, batch_size, *tensors):
+        """ """
         super(FastTensorDataset).__init__()
         self.batch_size = batch_size
-        self.tensors = tensors
+        self._tensors = tensors
         total_samples = tensors[0].shape[0]
-        self.indices = np.arange(total_samples)
-        self.len = total_samples // self.batch_size
+        self._indices = np.arange(total_samples)
+        self._len = total_samples // self.batch_size
 
     def __getitem__(self, idx):
         """
@@ -36,16 +50,16 @@ class FastTensorDataset(torch.utils.data.Dataset):
         batch : tuple
             The data tuple for this batch.
         """
-        batch = self.indices[
+        batch = self._indices[
             idx * self.batch_size : (idx + 1) * self.batch_size
         ]
-        rv = tuple(t[batch, ...] for t in self.tensors)
+        rv = tuple(t[batch, ...] for t in self._tensors)
         return rv
 
     def __len__(self):
         """Get the length of the data set."""
-        return self.len
+        return self._len
 
     def shuffle(self):
         """Shuffle the data set."""
-        np.random.shuffle(self.indices)
+        np.random.shuffle(self._indices)

--- a/mala/datahandling/lazy_load_dataset_single.py
+++ b/mala/datahandling/lazy_load_dataset_single.py
@@ -44,6 +44,56 @@ class LazyLoadDatasetSingle(Dataset):
 
     input_requires_grad : bool
         If True, then the gradient is stored for the inputs.
+
+    Attributes
+    ----------
+    allocated : bool
+        True if dataset is allocated.
+
+    currently_loaded_file : int
+        Index of currently loaded file
+
+    descriptor_calculator : mala.descriptors.descriptor.Descriptor
+        Used to do unit conversion on input data.
+
+    input_data : torch.Tensor
+        Input data tensor.
+
+    input_dtype : numpy.dtype
+        Input data type.
+
+    input_shape : list
+        Input data dimensions
+
+    input_shm_name : str
+        Name of shared memory allocated for input data
+
+    loaded : bool
+        True if data has been loaded to shared memory.
+
+    output_data : torch.Tensor
+        Output data tensor.
+
+    output_dtype : numpy.dtype
+        Output data dtype.
+
+    output_shape : list
+        Output data dimensions.
+
+    output_shm_name : str
+        Name of shared memory allocated for output data.
+
+    return_outputs_directly : bool
+
+        Control whether outputs are actually transformed.
+        Has to be False for training. In the testing case,
+        Numerical errors are smaller if set to True.
+
+    snapshot : mala.datahandling.snapshot.Snapshot
+        Currently loaded snapshot object.
+
+    target_calculator : mala.targets.target.Target or derivative
+        Used to do unit conversion on output data.
     """
 
     def __init__(
@@ -60,27 +110,24 @@ class LazyLoadDatasetSingle(Dataset):
         input_requires_grad=False,
     ):
         self.snapshot = snapshot
-        self.input_dimension = input_dimension
-        self.output_dimension = output_dimension
-        self.input_data_scaler = input_data_scaler
-        self.output_data_scaler = output_data_scaler
+        self._input_dimension = input_dimension
+        self._output_dimension = output_dimension
+        self._input_data_scaler = input_data_scaler
+        self._output_data_scaler = output_data_scaler
         self.descriptor_calculator = descriptor_calculator
         self.target_calculator = target_calculator
-        self.number_of_snapshots = 0
-        self.total_size = 0
-        self.descriptors_contain_xyz = (
-            self.descriptor_calculator.descriptors_contain_xyz
-        )
+        self._number_of_snapshots = 0
+        self._total_size = 0
         self.currently_loaded_file = None
         self.input_data = np.empty(0)
         self.output_data = np.empty(0)
-        self.use_ddp = use_ddp
+        self._use_ddp = use_ddp
         self.return_outputs_directly = False
-        self.input_requires_grad = input_requires_grad
+        self._input_requires_grad = input_requires_grad
 
-        self.batch_size = batch_size
-        self.len = int(np.ceil(snapshot.grid_size / self.batch_size))
-        self.indices = np.arange(snapshot.grid_size)
+        self._batch_size = batch_size
+        self._len = int(np.ceil(snapshot.grid_size / self._batch_size))
+        self._indices = np.arange(snapshot.grid_size)
         self.input_shm_name = None
         self.output_shm_name = None
         self.loaded = False
@@ -197,20 +244,20 @@ class LazyLoadDatasetSingle(Dataset):
         output_shm = shared_memory.SharedMemory(name=self.output_shm_name)
 
         input_data = np.ndarray(
-            shape=[self.snapshot.grid_size, self.input_dimension],
+            shape=[self.snapshot.grid_size, self._input_dimension],
             dtype=np.float32,
             buffer=input_shm.buf,
         )
         output_data = np.ndarray(
-            shape=[self.snapshot.grid_size, self.output_dimension],
+            shape=[self.snapshot.grid_size, self._output_dimension],
             dtype=np.float32,
             buffer=output_shm.buf,
         )
-        if idx == self.len - 1:
-            batch = self.indices[idx * self.batch_size :]
+        if idx == self._len - 1:
+            batch = self._indices[idx * self._batch_size :]
         else:
-            batch = self.indices[
-                idx * self.batch_size : (idx + 1) * self.batch_size
+            batch = self._indices[
+                idx * self._batch_size : (idx + 1) * self._batch_size
             ]
         # print(batch.shape)
 
@@ -219,12 +266,12 @@ class LazyLoadDatasetSingle(Dataset):
 
         # Perform conversion to tensor and perform transforms
         input_batch = torch.from_numpy(input_batch)
-        self.input_data_scaler.transform(input_batch)
-        input_batch.requires_grad = self.input_requires_grad
+        self._input_data_scaler.transform(input_batch)
+        input_batch.requires_grad = self._input_requires_grad
 
         if self.return_outputs_directly is False:
             output_batch = torch.from_numpy(output_batch)
-            self.output_data_scaler.transform(output_batch)
+            self._output_data_scaler.transform(output_batch)
 
         input_shm.close()
         output_shm.close()
@@ -240,7 +287,7 @@ class LazyLoadDatasetSingle(Dataset):
         length : int
             Number of data points in DataSet.
         """
-        return self.len
+        return self._len
 
     def mix_datasets(self):
         """
@@ -257,4 +304,4 @@ class LazyLoadDatasetSingle(Dataset):
         avoid erroneously overwriting shared memory data in cases where a
         single dataset object is used back to back.
         """
-        np.random.shuffle(self.indices)
+        np.random.shuffle(self._indices)

--- a/mala/datahandling/ldos_aligner.py
+++ b/mala/datahandling/ldos_aligner.py
@@ -33,6 +33,11 @@ class LDOSAligner(DataHandlerBase):
     target_calculator : mala.targets.target.Target
         Used to do unit conversion on output data. If None, then one will
         be created by this class.
+
+    Attributes
+    ----------
+    ldos_parameters : mala.common.parameters.ParametersTargets
+        MALA target calculation parameters.
     """
 
     def __init__(
@@ -85,8 +90,6 @@ class LDOSAligner(DataHandlerBase):
 
     def align_ldos_to_ref(
         self,
-        save_path=None,
-        save_name=None,
         save_path_ext="aligned/",
         reference_index=0,
         zero_tol=1e-5,
@@ -96,35 +99,34 @@ class LDOSAligner(DataHandlerBase):
         n_shift_mse=None,
     ):
         """
-        Add a snapshot to the data pipeline.
+        Align LDOS to reference.
 
         Parameters
         ----------
-        save_path : string
-            path to save the aligned LDOS vectors
-        save_name : string
-            naming convention for the aligned LDOS vectors
         save_path_ext : string
-            additional path for the LDOS vectors (useful if
-            save_path is left as default None)
+            Extra path to be added to the input path before saving.
+            By default, new snapshot files are saved into exactly the
+            same directory they were read from with exactly the same name.
+
         reference_index : int
             the snapshot number (in the snapshot directory list)
             to which all other LDOS vectors are aligned
+
         zero_tol : float
             the "zero" value for alignment / left side truncation
             always scaled by norm of reference LDOS mean
+
         left_truncate : bool
             whether to truncate the zero values on the LHS
+
         right_truncate_value : float
             right-hand energy value (based on reference LDOS vector)
             to which truncate LDOS vectors
             if None, no right-side truncation
-        egrid_spacing_ev : float
-            spacing of energy grid
-        egrid_offset_ev : float
-           original offset of energy grid
+
         number_of_electrons : float / int
             if not None, computes the energy shift relative to QE energies
+
         n_shift_mse : int
             how many energy grid points to consider when aligning LDOS
             vectors based on mean-squared error
@@ -304,10 +306,9 @@ class LDOSAligner(DataHandlerBase):
                 json.dump(ldos_shift_info, f, indent=2)
 
         barrier()
-    
+
     @staticmethod
     def calc_optimal_ldos_shift(
-        e_grid,
         ldos_mean,
         ldos_mean_ref,
         left_index,
@@ -322,8 +323,6 @@ class LDOSAligner(DataHandlerBase):
 
         Parameters
         ----------
-        e_grid : array_like
-            energy grid
         ldos_mean : array_like
             mean of LDOS vector for shifting
         ldos_mean_ref : array_like

--- a/mala/datahandling/multi_lazy_load_data_loader.py
+++ b/mala/datahandling/multi_lazy_load_data_loader.py
@@ -20,23 +20,23 @@ class MultiLazyLoadDataLoader:
     """
 
     def __init__(self, datasets, **kwargs):
-        self.datasets = datasets
-        self.loaders = []
+        self._datasets = datasets
+        self._loaders = []
         for d in datasets:
-            self.loaders.append(
+            self._loaders.append(
                 DataLoader(d, batch_size=None, **kwargs, shuffle=False)
             )
 
         # Create single process pool for prefetching
         # Can use ThreadPoolExecutor for debugging.
         # self.pool = concurrent.futures.ThreadPoolExecutor(1)
-        self.pool = concurrent.futures.ProcessPoolExecutor(1)
+        self._pool = concurrent.futures.ProcessPoolExecutor(1)
 
         # Allocate shared memory and commence file load for first
         # dataset in list
-        dset = self.datasets[0]
+        dset = self._datasets[0]
         dset.allocate_shared_mem()
-        self.load_future = self.pool.submit(
+        self._load_future = self._pool.submit(
             self.load_snapshot_to_shm,
             dset.snapshot,
             dset.descriptor_calculator,
@@ -54,7 +54,7 @@ class MultiLazyLoadDataLoader:
         length : int
             Number of datasets/snapshots contained within this loader.
         """
-        return len(self.loaders)
+        return len(self._loaders)
 
     def __iter__(self):
         """
@@ -66,7 +66,7 @@ class MultiLazyLoadDataLoader:
             An iterator over the individual datasets/snapshots in this
             object.
         """
-        self.count = 0
+        self._count = 0
         return self
 
     def __next__(self):
@@ -78,25 +78,25 @@ class MultiLazyLoadDataLoader:
         iterator: DataLoader
             The next data loader.
         """
-        self.count += 1
-        if self.count > len(self.loaders):
+        self._count += 1
+        if self._count > len(self._loaders):
             raise StopIteration
         else:
             # Wait on last prefetch
-            if self.count - 1 >= 0:
-                if not self.datasets[self.count - 1].loaded:
-                    self.load_future.result()
-                    self.datasets[self.count - 1].loaded = True
+            if self._count - 1 >= 0:
+                if not self._datasets[self._count - 1].loaded:
+                    self._load_future.result()
+                    self._datasets[self._count - 1].loaded = True
 
             # Delete last
-            if self.count - 2 >= 0:
-                self.datasets[self.count - 2].delete_data()
+            if self._count - 2 >= 0:
+                self._datasets[self._count - 2].delete_data()
 
             # Prefetch next file (looping around epoch boundary)
-            dset = self.datasets[self.count % len(self.loaders)]
+            dset = self._datasets[self._count % len(self._loaders)]
             if not dset.loaded:
                 dset.allocate_shared_mem()
-                self.load_future = self.pool.submit(
+                self._load_future = self._pool.submit(
                     self.load_snapshot_to_shm,
                     dset.snapshot,
                     dset.descriptor_calculator,
@@ -106,7 +106,7 @@ class MultiLazyLoadDataLoader:
                 )
 
             # Return current
-            return self.loaders[self.count - 1]
+            return self._loaders[self._count - 1]
 
     # TODO: Without this function, I get 2 times the number of snapshots
     # memory leaks after shutdown. With it, I get 1 times the number of
@@ -114,9 +114,9 @@ class MultiLazyLoadDataLoader:
     # enough? I am not sure where the memory leak is coming from.
     def cleanup(self):
         """Deallocate arrays still left in memory."""
-        for dset in self.datasets:
+        for dset in self._datasets:
             dset.deallocate_shared_mem()
-        self.pool.shutdown()
+        self._pool.shutdown()
 
     # Worker function to load data into shared memory (limited to numpy files
     # only for now)

--- a/mala/datahandling/snapshot.py
+++ b/mala/datahandling/snapshot.py
@@ -45,10 +45,6 @@ class Snapshot(JSONSerializable):
 
     Attributes
     ----------
-    calculation_output : string
-        File with the output of the original snapshot calculation. This is
-        only needed when testing multiple snapshots.
-
     grid_dimensions :  list
         Grid dimension [x,y,z].
 

--- a/mala/datahandling/snapshot.py
+++ b/mala/datahandling/snapshot.py
@@ -43,8 +43,58 @@ class Snapshot(JSONSerializable):
           - tr: This snapshot will be a training snapshot.
           - va: This snapshot will be a validation snapshot.
 
-        Replaces the old approach of MALA to have a separate list.
-        Default is None.
+    Attributes
+    ----------
+    calculation_output : string
+        File with the output of the original snapshot calculation. This is
+        only needed when testing multiple snapshots.
+
+    grid_dimensions :  list
+        Grid dimension [x,y,z].
+
+    grid_size : int
+        Number of grid points in total.
+
+    input_dimension : int
+        Input feature dimension.
+
+    output_dimension : int
+        Output feature dimension
+
+    input_npy_file : string
+        File with saved numpy input array.
+
+    input_npy_directory : string
+        Directory containing input_npy_directory.
+
+    output_npy_file : string
+        File with saved numpy output array.
+
+    output_npy_directory : string
+        Directory containing output_npy_file.
+
+    input_units : string
+        Units of input data. See descriptor classes to see which units are
+        supported.
+
+    output_units : string
+        Units of output data. See target classes to see which units are
+        supported.
+
+    calculation_output : string
+        File with the output of the original snapshot calculation. This is
+        only needed when testing multiple snapshots.
+
+    snapshot_function : string
+        "Function" of the snapshot in the MALA workflow.
+
+          - te: This snapshot will be a testing snapshot.
+          - tr: This snapshot will be a training snapshot.
+          - va: This snapshot will be a validation snapshot.
+
+    snapshot_type : string
+        Can be either "numpy" or "openpmd" and denotes which type of files
+        this snapshot contains.
     """
 
     def __init__(

--- a/mala/descriptors/atomic_density.py
+++ b/mala/descriptors/atomic_density.py
@@ -31,17 +31,11 @@ class AtomicDensity(Descriptor):
 
     def __init__(self, parameters):
         super(AtomicDensity, self).__init__(parameters)
-        self.verbosity = parameters.verbosity
 
     @property
     def data_name(self):
         """Get a string that describes the target (for e.g. metadata)."""
         return "AtomicDensity"
-
-    @property
-    def feature_size(self):
-        """Get the feature dimension of this data."""
-        return self.fingerprint_length
 
     @staticmethod
     def convert_units(array, in_units="None"):
@@ -140,7 +134,7 @@ class AtomicDensity(Descriptor):
         self.setup_lammps_tmp_files("ggrid", outdir)
 
         ase.io.write(
-            self.lammps_temporary_input, self.atoms, format=lammps_format
+            self._lammps_temporary_input, self._atoms, format=lammps_format
         )
 
         nx = self.grid_dimensions[0]
@@ -151,7 +145,7 @@ class AtomicDensity(Descriptor):
         if self.parameters.atomic_density_sigma is None:
             self.grid_dimensions = [nx, ny, nz]
             self.parameters.atomic_density_sigma = self.get_optimal_sigma(
-                self.voxel
+                self._voxel
             )
 
         # Create LAMMPS instance.
@@ -213,7 +207,7 @@ class AtomicDensity(Descriptor):
             if return_directly:
                 return gaussian_descriptors_np
             else:
-                self.fingerprint_length = 4
+                self.feature_size = 4
                 return gaussian_descriptors_np, nrows_ggrid
         else:
             # Since the atomic density may be directly fed back into QE
@@ -238,10 +232,10 @@ class AtomicDensity(Descriptor):
                     [2, 1, 0, 3]
                 )
                 if self.parameters.descriptors_contain_xyz:
-                    self.fingerprint_length = 4
+                    self.feature_size = 4
                     return gaussian_descriptors_np[:, :, :, 3:], nx * ny * nz
                 else:
-                    self.fingerprint_length = 1
+                    self.feature_size = 1
                     return gaussian_descriptors_np[:, :, :, 6:], nx * ny * nz
 
     def __calculate_python(self, **kwargs):
@@ -281,7 +275,7 @@ class AtomicDensity(Descriptor):
         # This follows the implementation in the LAMMPS code.
         if self.parameters.atomic_density_sigma is None:
             self.parameters.atomic_density_sigma = self.get_optimal_sigma(
-                self.voxel
+                self._voxel
             )
         cutoff_squared = (
             self.parameters.atomic_density_cutoff
@@ -329,10 +323,10 @@ class AtomicDensity(Descriptor):
                     )
 
         if self.parameters.descriptors_contain_xyz:
-            self.fingerprint_length = 4
+            self.feature_size = 4
             return gaussian_descriptors_np, np.prod(self.grid_dimensions)
         else:
-            self.fingerprint_length = 1
+            self.feature_size = 1
             return gaussian_descriptors_np[:, :, :, 3:], np.prod(
                 self.grid_dimensions
             )

--- a/mala/descriptors/bispectrum.py
+++ b/mala/descriptors/bispectrum.py
@@ -57,11 +57,6 @@ class Bispectrum(Descriptor):
         """Get a string that describes the target (for e.g. metadata)."""
         return "Bispectrum"
 
-    @property
-    def feature_size(self):
-        """Get the feature dimension of this data."""
-        return self.fingerprint_length
-
     @staticmethod
     def convert_units(array, in_units="None"):
         """
@@ -144,7 +139,7 @@ class Bispectrum(Descriptor):
         self.setup_lammps_tmp_files("bgrid", outdir)
 
         ase.io.write(
-            self.lammps_temporary_input, self.atoms, format=lammps_format
+            self._lammps_temporary_input, self._atoms, format=lammps_format
         )
 
         nx = self.grid_dimensions[0]
@@ -190,7 +185,7 @@ class Bispectrum(Descriptor):
             * (self.parameters.bispectrum_twojmax + 4)
         )
         ncoeff = ncoeff // 24  # integer division
-        self.fingerprint_length = ncols0 + ncoeff
+        self.feature_size = ncols0 + ncoeff
 
         # Extract data from LAMMPS calculation.
         # This is different for the parallel and the serial case.
@@ -210,7 +205,7 @@ class Bispectrum(Descriptor):
                 lammps_constants.LMP_STYLE_LOCAL,
                 lammps_constants.LMP_SIZE_COLS,
             )
-            if ncols_local != self.fingerprint_length + 3:
+            if ncols_local != self.feature_size + 3:
                 raise Exception("Inconsistent number of features.")
 
             snap_descriptors_np = extract_compute_np(
@@ -235,7 +230,7 @@ class Bispectrum(Descriptor):
                 "bgrid",
                 0,
                 2,
-                (nz, ny, nx, self.fingerprint_length),
+                (nz, ny, nx, self.feature_size),
                 use_fp64=use_fp64,
             )
 
@@ -297,13 +292,13 @@ class Bispectrum(Descriptor):
             * (self.parameters.bispectrum_twojmax + 4)
         )
         ncoeff = ncoeff // 24  # integer division
-        self.fingerprint_length = ncoeff + 3
+        self.feature_size = ncoeff + 3
         bispectrum_np = np.zeros(
             (
                 self.grid_dimensions[0],
                 self.grid_dimensions[1],
                 self.grid_dimensions[2],
-                self.fingerprint_length,
+                self.feature_size,
             ),
             dtype=np.float64,
         )
@@ -313,16 +308,16 @@ class Bispectrum(Descriptor):
 
         # These are technically hyperparameters. We currently simply set them
         # to set values for everything.
-        self.rmin0 = 0.0
-        self.rfac0 = 0.99363
-        self.bzero_flag = False
-        self.wselfall_flag = False
+        self._rmin0 = 0.0
+        self._rfac0 = 0.99363
+        self._bzero_flag = False
+        self._wselfall_flag = False
         # Currently not supported
-        self.bnorm_flag = False
+        self._bnorm_flag = False
         # Currently not supported
-        self.quadraticflag = False
-        self.number_elements = 1
-        self.wself = 1.0
+        self._quadraticflag = False
+        self._python_calculation_number_elements = 1
+        self._wself = 1.0
 
         # What follows is the python implementation of the
         # bispectrum descriptor calculation.
@@ -496,7 +491,7 @@ class Bispectrum(Descriptor):
         if self.parameters.descriptors_contain_xyz:
             return bispectrum_np, np.prod(self.grid_dimensions)
         else:
-            self.fingerprint_length -= 3
+            self.feature_size -= 3
             return bispectrum_np[:, :, :, 3:], np.prod(self.grid_dimensions)
 
     ########
@@ -902,10 +897,10 @@ class Bispectrum(Descriptor):
         """
         # Precompute and prepare ui stuff
         theta0 = (
-            (distances_cutoff - self.rmin0)
-            * self.rfac0
+            (distances_cutoff - self._rmin0)
+            * self._rfac0
             * np.pi
-            / (self.parameters.bispectrum_cutoff - self.rmin0)
+            / (self.parameters.bispectrum_cutoff - self._rmin0)
         )
         z0 = np.squeeze(distances_cutoff / np.tan(theta0))
 
@@ -986,13 +981,14 @@ class Bispectrum(Descriptor):
                 sfac += 1.0
             else:
                 rcutfac = np.pi / (
-                    self.parameters.bispectrum_cutoff - self.rmin0
+                    self.parameters.bispectrum_cutoff - self._rmin0
                 )
                 if nr_atoms > 1:
                     sfac = 0.5 * (
-                        np.cos((distances_cutoff - self.rmin0) * rcutfac) + 1.0
+                        np.cos((distances_cutoff - self._rmin0) * rcutfac)
+                        + 1.0
                     )
-                    sfac[np.where(distances_cutoff <= self.rmin0)] = 1.0
+                    sfac[np.where(distances_cutoff <= self._rmin0)] = 1.0
                     sfac[
                         np.where(
                             distances_cutoff
@@ -1000,8 +996,8 @@ class Bispectrum(Descriptor):
                         )
                     ] = 0.0
                 else:
-                    sfac = 1.0 if distances_cutoff <= self.rmin0 else sfac
-                    sfac = 0.0 if distances_cutoff <= self.rmin0 else sfac
+                    sfac = 1.0 if distances_cutoff <= self._rmin0 else sfac
+                    sfac = 0.0 if distances_cutoff <= self._rmin0 else sfac
 
             # sfac technically has to be weighted according to the chemical
             # species. But this is a minimal implementation only for a single
@@ -1099,12 +1095,12 @@ class Bispectrum(Descriptor):
         itriple = 0
         idouble = 0
 
-        if self.bzero_flag:
+        if self._bzero_flag:
             wself = 1.0
             bzero = np.zeros(self.parameters.bispectrum_twojmax + 1)
             www = wself * wself * wself
             for j in range(self.parameters.bispectrum_twojmax + 1):
-                if self.bnorm_flag:
+                if self._bnorm_flag:
                     bzero[j] = www
                 else:
                     bzero[j] = www * (j + 1)
@@ -1158,8 +1154,8 @@ class Bispectrum(Descriptor):
                     itriple += 1
                 idouble += 1
 
-        if self.bzero_flag:
-            if not self.wselfall_flag:
+        if self._bzero_flag:
+            if not self._wselfall_flag:
                 itriple = (
                     ielem * number_elements + ielem
                 ) * number_elements + ielem
@@ -1179,9 +1175,9 @@ class Bispectrum(Descriptor):
                             itriple += 1
 
         # Untested  & Unoptimized
-        if self.quadraticflag:
+        if self._quadraticflag:
             xyz_length = 3 if self.parameters.descriptors_contain_xyz else 0
-            ncount = self.fingerprint_length - xyz_length
+            ncount = self.feature_size - xyz_length
             for icoeff in range(ncount):
                 bveci = blist[icoeff]
                 blist[3 + ncount] = 0.5 * bveci * bveci

--- a/mala/descriptors/descriptor.py
+++ b/mala/descriptors/descriptor.py
@@ -36,6 +36,10 @@ class Descriptor(PhysicalData):
     parameters : mala.common.parameters.Parameters
         Parameters object used to create this object.
 
+    Attributes
+    ----------
+    parameters: mala.common.parameters.ParametersDescriptors
+        MALA descriptor calculation parameters.
     """
 
     ##############################
@@ -106,17 +110,16 @@ class Descriptor(PhysicalData):
     def __init__(self, parameters):
         super(Descriptor, self).__init__(parameters)
         self.parameters: ParametersDescriptors = parameters.descriptors
-        self.fingerprint_length = 0  # so iterations will fail
-        self.verbosity = parameters.verbosity
-        self.in_format_ase = ""
-        self.atoms = None
-        self.voxel = None
+        self.feature_size = 0  # so iterations will fail
+        self._in_format_ase = ""
+        self._atoms = None
+        self._voxel = None
 
         # If we ever have NON LAMMPS descriptors, these parameters have no
         # meaning anymore and should probably be moved to an intermediate
         # DescriptorsLAMMPS class, from which the LAMMPS descriptors inherit.
-        self.lammps_temporary_input = None
-        self.lammps_temporary_log = None
+        self._lammps_temporary_input = None
+        self._lammps_temporary_log = None
 
     ##############################
     # Properties
@@ -182,6 +185,15 @@ class Descriptor(PhysicalData):
             " descriptor type."
         )
 
+    @property
+    def feature_size(self):
+        """Get the feature dimension of this data."""
+        return self._feature_size
+
+    @feature_size.setter
+    def feature_size(self, value):
+        self._feature_size = value
+
     @staticmethod
     def backconvert_units(array, out_units):
         """
@@ -227,24 +239,24 @@ class Descriptor(PhysicalData):
             lammps_tmp_input_file = tempfile.NamedTemporaryFile(
                 delete=False, prefix=prefix_inp_str, suffix="_.tmp", dir=outdir
             )
-            self.lammps_temporary_input = lammps_tmp_input_file.name
+            self._lammps_temporary_input = lammps_tmp_input_file.name
             lammps_tmp_input_file.close()
 
             lammps_tmp_log_file = tempfile.NamedTemporaryFile(
                 delete=False, prefix=prefix_log_str, suffix="_.tmp", dir=outdir
             )
-            self.lammps_temporary_log = lammps_tmp_log_file.name
+            self._lammps_temporary_log = lammps_tmp_log_file.name
             lammps_tmp_log_file.close()
         else:
-            self.lammps_temporary_input = None
-            self.lammps_temporary_log = None
+            self._lammps_temporary_input = None
+            self._lammps_temporary_log = None
 
         if self.parameters._configuration["mpi"]:
-            self.lammps_temporary_input = get_comm().bcast(
-                self.lammps_temporary_input, root=0
+            self._lammps_temporary_input = get_comm().bcast(
+                self._lammps_temporary_input, root=0
             )
-            self.lammps_temporary_log = get_comm().bcast(
-                self.lammps_temporary_log, root=0
+            self._lammps_temporary_log = get_comm().bcast(
+                self._lammps_temporary_log, root=0
             )
 
     # Calculations
@@ -328,13 +340,13 @@ class Descriptor(PhysicalData):
             (x,y,z,descriptor_dimension)
 
         """
-        self.in_format_ase = "espresso-out"
+        self._in_format_ase = "espresso-out"
         printout("Calculating descriptors from", qe_out_file, min_verbosity=0)
         # We get the atomic information by using ASE.
-        self.atoms = ase.io.read(qe_out_file, format=self.in_format_ase)
+        self._atoms = ase.io.read(qe_out_file, format=self._in_format_ase)
 
         # Enforcing / Checking PBC on the read atoms.
-        self.atoms = self.enforce_pbc(self.atoms)
+        self._atoms = self.enforce_pbc(self._atoms)
 
         # Get the grid dimensions.
         if "grid_dimensions" in kwargs.keys():
@@ -356,10 +368,10 @@ class Descriptor(PhysicalData):
                     self.grid_dimensions[2] = int(tmp.split(",")[2])
                     break
 
-        self.voxel = self.atoms.cell.copy()
-        self.voxel[0] = self.voxel[0] / (self.grid_dimensions[0])
-        self.voxel[1] = self.voxel[1] / (self.grid_dimensions[1])
-        self.voxel[2] = self.voxel[2] / (self.grid_dimensions[2])
+        self._voxel = self._atoms.cell.copy()
+        self._voxel[0] = self._voxel[0] / (self.grid_dimensions[0])
+        self._voxel[1] = self._voxel[1] / (self.grid_dimensions[1])
+        self._voxel[2] = self._voxel[2] / (self.grid_dimensions[2])
 
         return self._calculate(working_directory, **kwargs)
 
@@ -400,12 +412,12 @@ class Descriptor(PhysicalData):
             (x,y,z,descriptor_dimension)
         """
         # Enforcing / Checking PBC on the input atoms.
-        self.atoms = self.enforce_pbc(atoms)
+        self._atoms = self.enforce_pbc(atoms)
         self.grid_dimensions = grid_dimensions
-        self.voxel = self.atoms.cell.copy()
-        self.voxel[0] = self.voxel[0] / (self.grid_dimensions[0])
-        self.voxel[1] = self.voxel[1] / (self.grid_dimensions[1])
-        self.voxel[2] = self.voxel[2] / (self.grid_dimensions[2])
+        self._voxel = self._atoms.cell.copy()
+        self._voxel[0] = self._voxel[0] / (self.grid_dimensions[0])
+        self._voxel[1] = self._voxel[1] / (self.grid_dimensions[1])
+        self._voxel[2] = self._voxel[2] / (self.grid_dimensions[2])
         return self._calculate(working_directory, **kwargs)
 
     def gather_descriptors(self, descriptors_np, use_pickled_comm=False):
@@ -445,7 +457,7 @@ class Descriptor(PhysicalData):
             sendcounts = np.array(
                 comm.gather(np.shape(descriptors_np)[0], root=0)
             )
-            raw_feature_length = self.fingerprint_length + 3
+            raw_feature_length = self.feature_size + 3
 
             if get_rank() == 0:
                 # print("sendcounts: {}, total: {}".format(sendcounts,
@@ -490,7 +502,7 @@ class Descriptor(PhysicalData):
             nx = self.grid_dimensions[0]
             ny = self.grid_dimensions[1]
             nz = self.grid_dimensions[2]
-            descriptors_full = np.zeros([nx, ny, nz, self.fingerprint_length])
+            descriptors_full = np.zeros([nx, ny, nz, self.feature_size])
             # Fill the full bispectrum descriptors array.
             for idx, local_grid in enumerate(all_descriptors_list):
                 # We glue the individual cells back together, and transpose.
@@ -508,7 +520,7 @@ class Descriptor(PhysicalData):
                         last_z - first_z,
                         last_y - first_y,
                         last_x - first_x,
-                        self.fingerprint_length,
+                        self.feature_size,
                     ],
                 ).transpose(
                     [2, 1, 0, 3]
@@ -554,10 +566,10 @@ class Descriptor(PhysicalData):
         ny = local_reach[1] - local_offset[1]
         nz = local_reach[2] - local_offset[2]
 
-        descriptors_full = np.zeros([nx, ny, nz, self.fingerprint_length])
+        descriptors_full = np.zeros([nx, ny, nz, self.feature_size])
 
         descriptors_full[0:nx, 0:ny, 0:nz] = np.reshape(
-            descriptors_np[:, 3:], [nz, ny, nx, self.fingerprint_length]
+            descriptors_np[:, 3:], [nz, ny, nx, self.feature_size]
         ).transpose([2, 1, 0, 3])
         return descriptors_full, local_offset, local_reach
 
@@ -580,20 +592,20 @@ class Descriptor(PhysicalData):
 
     def _set_geometry_info(self, mesh):
         # Geometry: Save the cell parameters and angles of the grid.
-        if self.atoms is not None:
+        if self._atoms is not None:
             import openpmd_api as io
 
-            self.voxel = self.atoms.cell.copy()
-            self.voxel[0] = self.voxel[0] / (self.grid_dimensions[0])
-            self.voxel[1] = self.voxel[1] / (self.grid_dimensions[1])
-            self.voxel[2] = self.voxel[2] / (self.grid_dimensions[2])
+            self._voxel = self._atoms.cell.copy()
+            self._voxel[0] = self._voxel[0] / (self.grid_dimensions[0])
+            self._voxel[1] = self._voxel[1] / (self.grid_dimensions[1])
+            self._voxel[2] = self._voxel[2] / (self.grid_dimensions[2])
 
             mesh.geometry = io.Geometry.cartesian
-            mesh.grid_spacing = self.voxel.cellpar()[0:3]
-            mesh.set_attribute("angles", self.voxel.cellpar()[3:])
+            mesh.grid_spacing = self._voxel.cellpar()[0:3]
+            mesh.set_attribute("angles", self._voxel.cellpar()[3:])
 
     def _get_atoms(self):
-        return self.atoms
+        return self._atoms
 
     def _feature_mask(self):
         if self.descriptors_contain_xyz:
@@ -614,9 +626,9 @@ class Descriptor(PhysicalData):
             "-screen",
             "none",
             "-log",
-            self.lammps_temporary_log,
+            self._lammps_temporary_log,
         ]
-        lammps_dict["atom_config_fname"] = self.lammps_temporary_input
+        lammps_dict["atom_config_fname"] = self._lammps_temporary_input
 
         if self.parameters._configuration["mpi"]:
             size = get_size()
@@ -833,8 +845,8 @@ class Descriptor(PhysicalData):
         lmp.close()
         if not keep_logs:
             if get_rank() == 0:
-                os.remove(self.lammps_temporary_log)
-                os.remove(self.lammps_temporary_input)
+                os.remove(self._lammps_temporary_log)
+                os.remove(self._lammps_temporary_input)
 
     def _setup_atom_list(self):
         """
@@ -847,7 +859,7 @@ class Descriptor(PhysicalData):
         FURTHER OPTIMIZATION: Probably not that much, this mostly already uses
         optimized python functions.
         """
-        if np.any(self.atoms.pbc):
+        if np.any(self._atoms.pbc):
 
             # To determine the list of relevant atoms we first take the edges
             # of the simulation cell and use them to determine all cells
@@ -874,19 +886,19 @@ class Descriptor(PhysicalData):
             for edge in edges:
                 edge_point = self._grid_to_coord(edge)
                 neighborlist = NeighborList(
-                    np.zeros(len(self.atoms) + 1)
+                    np.zeros(len(self._atoms) + 1)
                     + [self.parameters.atomic_density_cutoff],
                     bothways=True,
                     self_interaction=False,
                     primitive=NewPrimitiveNeighborList,
                 )
 
-                atoms_with_grid_point = self.atoms.copy()
+                atoms_with_grid_point = self._atoms.copy()
 
                 # Construct a ghost atom representing the grid point.
                 atoms_with_grid_point.append(ase.Atom("H", edge_point))
                 neighborlist.update(atoms_with_grid_point)
-                indices, offsets = neighborlist.get_neighbors(len(self.atoms))
+                indices, offsets = neighborlist.get_neighbors(len(self._atoms))
 
                 # Incrementally fill the list containing all cells to be
                 # considered.
@@ -911,18 +923,18 @@ class Descriptor(PhysicalData):
             # First, instantiate it by filling it will all atoms from all
             # potentiall relevant cells, as identified above.
             all_atoms = None
-            for a in range(0, len(self.atoms)):
+            for a in range(0, len(self._atoms)):
                 if all_atoms is None:
                     all_atoms = (
-                        self.atoms.positions[a]
-                        + all_cells @ self.atoms.get_cell()
+                        self._atoms.positions[a]
+                        + all_cells @ self._atoms.get_cell()
                     )
                 else:
                     all_atoms = np.concatenate(
                         (
                             all_atoms,
-                            self.atoms.positions[a]
-                            + all_cells @ self.atoms.get_cell(),
+                            self._atoms.positions[a]
+                            + all_cells @ self._atoms.get_cell(),
                         )
                     )
 
@@ -975,11 +987,11 @@ class Descriptor(PhysicalData):
                     :,
                 ]
             )
-            return np.concatenate((all_atoms, self.atoms.positions))
+            return np.concatenate((all_atoms, self._atoms.positions))
 
         else:
             # If no PBC are used, only consider a single cell.
-            return self.atoms.positions
+            return self._atoms.positions
 
     def _grid_to_coord(self, gridpoint):
         # Convert grid indices to real space grid point.
@@ -989,20 +1001,20 @@ class Descriptor(PhysicalData):
         # Orthorhombic cells and triclinic ones have
         # to be treated differently, see domain.cpp
 
-        if self.atoms.cell.orthorhombic:
-            return np.diag(self.voxel) * [i, j, k]
+        if self._atoms.cell.orthorhombic:
+            return np.diag(self._voxel) * [i, j, k]
         else:
             ret = [0, 0, 0]
             ret[0] = (
-                i / self.grid_dimensions[0] * self.atoms.cell[0, 0]
-                + j / self.grid_dimensions[1] * self.atoms.cell[1, 0]
-                + k / self.grid_dimensions[2] * self.atoms.cell[2, 0]
+                i / self.grid_dimensions[0] * self._atoms.cell[0, 0]
+                + j / self.grid_dimensions[1] * self._atoms.cell[1, 0]
+                + k / self.grid_dimensions[2] * self._atoms.cell[2, 0]
             )
             ret[1] = (
-                j / self.grid_dimensions[1] * self.atoms.cell[1, 1]
-                + k / self.grid_dimensions[2] * self.atoms.cell[1, 2]
+                j / self.grid_dimensions[1] * self._atoms.cell[1, 1]
+                + k / self.grid_dimensions[2] * self._atoms.cell[1, 2]
             )
-            ret[2] = k / self.grid_dimensions[2] * self.atoms.cell[2, 2]
+            ret[2] = k / self.grid_dimensions[2] * self._atoms.cell[2, 2]
             return np.array(ret)
 
     @abstractmethod
@@ -1010,4 +1022,4 @@ class Descriptor(PhysicalData):
         pass
 
     def _set_feature_size_from_array(self, array):
-        self.fingerprint_length = np.shape(array)[-1]
+        self.feature_size = np.shape(array)[-1]

--- a/mala/descriptors/minterpy_descriptors.py
+++ b/mala/descriptors/minterpy_descriptors.py
@@ -1,4 +1,4 @@
-"""Gaussian descriptor class."""
+"""Minterpy descriptor class."""
 
 import os
 
@@ -10,10 +10,14 @@ import numpy as np
 from mala.descriptors.lammps_utils import extract_compute_np
 from mala.descriptors.descriptor import Descriptor
 from mala.descriptors.atomic_density import AtomicDensity
+from mala.common.parallelizer import parallel_warn
 
 
 class MinterpyDescriptors(Descriptor):
-    """Class for calculation and parsing of Gaussian descriptors.
+    """
+    Class for calculation and parsing of Minterpy descriptors.
+
+    Marked for deprecation.
 
     Parameters
     ----------
@@ -23,17 +27,15 @@ class MinterpyDescriptors(Descriptor):
 
     def __init__(self, parameters):
         super(MinterpyDescriptors, self).__init__(parameters)
-        self.verbosity = parameters.verbosity
+        parallel_warn(
+            "Minterpy descriptors will be deprecated starting with MALA v1.4.0",
+            category=FutureWarning,
+        )
 
     @property
     def data_name(self):
         """Get a string that describes the target (for e.g. metadata)."""
         return "Minterpy"
-
-    @property
-    def feature_size(self):
-        """Get the feature dimension of this data."""
-        return self.fingerprint_length
 
     @staticmethod
     def convert_units(array, in_units="None"):
@@ -149,11 +151,11 @@ class MinterpyDescriptors(Descriptor):
             ],
             dtype=np.float64,
         )
-        self.fingerprint_length = (
+        self.feature_size = (
             len(self.parameters.minterpy_point_list) + coord_length
         )
 
-        self.fingerprint_length = len(self.parameters.minterpy_point_list)
+        self.feature_size = len(self.parameters.minterpy_point_list)
         # Perform one LAMMPS call for each point in the Minterpy point list.
         for idx, point in enumerate(self.parameters.minterpy_point_list):
             # Shift the atoms in negative direction of the point(s) we actually
@@ -166,7 +168,7 @@ class MinterpyDescriptors(Descriptor):
             self.setup_lammps_tmp_files("minterpy", outdir)
 
             ase.io.write(
-                self.lammps_temporary_input, self.atoms, format=lammps_format
+                self._lammps_temporary_input, self._atoms, format=lammps_format
             )
 
             # Create LAMMPS instance.

--- a/mala/interfaces/ase_calculator.py
+++ b/mala/interfaces/ase_calculator.py
@@ -46,9 +46,6 @@ class MALA(Calculator):
 
     last_energy_contributions : dict
         Contains all total energy contributions for the last prediction.
-
-    implemented_properties : list
-        List of which properties can be computed by this calculator.
     """
 
     implemented_properties = ["energy"]

--- a/mala/network/hyper_opt.py
+++ b/mala/network/hyper_opt.py
@@ -24,6 +24,11 @@ class HyperOpt(ABC):
 
     use_pkl_checkpoints : bool
         If true, .pkl checkpoints will be created.
+
+    Attributes
+    ----------
+    params : mala.common.parametes.Parameters
+        MALA Parameters object.
     """
 
     def __new__(cls, params: Parameters, data=None, use_pkl_checkpoints=False):
@@ -73,9 +78,9 @@ class HyperOpt(ABC):
         self, params: Parameters, data=None, use_pkl_checkpoints=False
     ):
         self.params: Parameters = params
-        self.data_handler = data
-        self.objective = ObjectiveBase(self.params, self.data_handler)
-        self.use_pkl_checkpoints = use_pkl_checkpoints
+        self._data_handler = data
+        self._objective = ObjectiveBase(self.params, self._data_handler)
+        self._use_pkl_checkpoints = use_pkl_checkpoints
 
     def add_hyperparameter(
         self, opttype="float", name="", low=0, high=0, choices=None
@@ -153,7 +158,7 @@ class HyperOpt(ABC):
         The parameters will be written to the parameter object with which the
         hyperparameter optimizer was created.
         """
-        self.objective.parse_trial(trial)
+        self._objective.parse_trial(trial)
 
     def _save_params_and_scaler(self):
         # Saving the Scalers is straight forward.
@@ -163,12 +168,12 @@ class HyperOpt(ABC):
         oscaler_name = (
             self.params.hyperparameters.checkpoint_name + "_oscaler.pkl"
         )
-        self.data_handler.input_data_scaler.save(iscaler_name)
-        self.data_handler.output_data_scaler.save(oscaler_name)
+        self._data_handler.input_data_scaler.save(iscaler_name)
+        self._data_handler.output_data_scaler.save(oscaler_name)
 
         # For the parameters we have to make sure we choose the correct
         # format.
-        if self.use_pkl_checkpoints:
+        if self._use_pkl_checkpoints:
             param_name = (
                 self.params.hyperparameters.checkpoint_name + "_params.pkl"
             )
@@ -198,7 +203,6 @@ class HyperOpt(ABC):
         -------
         checkpoint_exists : bool
             True if the checkpoint exists, False otherwise.
-
         """
         iscaler_name = checkpoint_name + "_iscaler.pkl"
         oscaler_name = checkpoint_name + "_oscaler.pkl"

--- a/mala/network/hyper_opt_oat.py
+++ b/mala/network/hyper_opt_oat.py
@@ -14,7 +14,7 @@ except ModuleNotFoundError:
 from mala.network.hyper_opt import HyperOpt
 from mala.network.objective_base import ObjectiveBase
 from mala.network.hyperparameter_oat import HyperparameterOAT
-from mala.common.parallelizer import printout
+from mala.common.parallelizer import printout, parallel_warn
 
 
 class HyperOptOAT(HyperOpt):
@@ -38,22 +38,55 @@ class HyperOptOAT(HyperOpt):
         super(HyperOptOAT, self).__init__(
             params, data, use_pkl_checkpoints=use_pkl_checkpoints
         )
-        self.objective = None
-        self.optimal_params = None
-        self.checkpoint_counter = 0
+        self._objective = None
+        self._optimal_params = None
+        self._checkpoint_counter = 0
 
         # Related to the OA itself.
-        self.importance = None
-        self.n_factors = None
-        self.factor_levels = None
-        self.strength = None
-        self.N_runs = None
+        self._importance = None
+        self._n_factors = None
+        self._factor_levels = None
+        self._strength = None
+        self._N_runs = None
         self.__OA = None
 
         # Tracking the trial progress.
-        self.sorted_num_choices = []
-        self.current_trial = 0
-        self.trial_losses = None
+        self._sorted_num_choices = []
+        self._current_trial = 0
+        self._trial_losses = None
+
+    @property
+    def best_trial_index(self):
+        """
+        Get the index and loss of best trial determined in this NASWOT run.
+
+        This property is read only, and will be recomputed.
+
+        Returns
+        -------
+        best_trial_index : list
+            A list containing [0] the best trial index and [1] the best
+            trial loss.
+        """
+        if self._trial_losses is None:
+            parallel_warn(
+                "Trial list is not yet computed, cannot determine "
+                "best trial."
+            )
+            return [-1, np.inf]
+
+        if self.params.hyperparameters.direction == "minimize":
+            return [np.argmin(self._trial_losses), np.min(self._trial_losses)]
+        elif self.params.hyperparameters.direction == "maximize":
+            return [np.argmax(self._trial_losses), np.max(self._trial_losses)]
+        else:
+            raise Exception(
+                "Invalid direction for hyperparameter optimization selected."
+            )
+
+    @best_trial_index.setter
+    def best_trial_index(self, value):
+        pass
 
     def add_hyperparameter(
         self, opttype="categorical", name="", choices=None, **kwargs
@@ -70,15 +103,15 @@ class HyperOptOAT(HyperOpt):
             Datatype of the hyperparameter. Follows optuna's naming
             conventions, but currently only supports "categorical" (a list).
         """
-        if not self.sorted_num_choices:  # if empty
+        if not self._sorted_num_choices:  # if empty
             super(HyperOptOAT, self).add_hyperparameter(
                 opttype=opttype, name=name, choices=choices
             )
-            self.sorted_num_choices.append(len(choices))
+            self._sorted_num_choices.append(len(choices))
 
         else:
-            index = bisect(self.sorted_num_choices, len(choices))
-            self.sorted_num_choices.insert(index, len(choices))
+            index = bisect(self._sorted_num_choices, len(choices))
+            self._sorted_num_choices.insert(index, len(choices))
             self.params.hyperparameters.hlist.insert(
                 index,
                 HyperparameterOAT(opttype=opttype, name=name, choices=choices),
@@ -88,50 +121,50 @@ class HyperOptOAT(HyperOpt):
         """
         Perform the study, i.e. the optimization.
 
-        Uses Optunas TPE sampler.
+        Internally constructs an orthogonal array and performs trial NN
+        trainings based on it.
         """
         if self.__OA is None:
-            self.__OA = self.get_orthogonal_array()
+            self.__OA = self._get_orthogonal_array()
         print(self.__OA)
-        if self.trial_losses is None:
-            self.trial_losses = np.zeros(self.__OA.shape[0]) + float("inf")
+        if self._trial_losses is None:
+            self._trial_losses = np.zeros(self.__OA.shape[0]) + float("inf")
 
         printout(
             "Performing",
-            self.N_runs,
+            self._N_runs,
             "trials, starting with trial number",
-            self.current_trial,
+            self._current_trial,
             min_verbosity=0,
         )
 
         # The parameters could have changed.
-        self.objective = ObjectiveBase(self.params, self.data_handler)
+        self._objective = ObjectiveBase(self.params, self._data_handler)
 
         # Iterate over the OA and perform the trials.
-        for i in range(self.current_trial, self.N_runs):
+        for i in range(self._current_trial, self._N_runs):
             row = self.__OA[i]
-            self.trial_losses[self.current_trial] = self.objective(row)
+            self._trial_losses[self._current_trial] = self._objective(row)
 
             # Output diagnostic information.
-            best_trial = self.get_best_trial_results()
             printout(
                 "Trial number",
-                self.current_trial,
+                self._current_trial,
                 "finished with:",
-                self.trial_losses[self.current_trial],
+                self._trial_losses[self._current_trial],
                 ", best is trial",
-                best_trial[0],
+                self.best_trial_index[0],
                 "with",
-                best_trial[1],
+                self.best_trial_index[1],
                 min_verbosity=0,
             )
-            self.current_trial += 1
+            self._current_trial += 1
             self.__create_checkpointing(row)
 
         # Perform Range Analysis
-        self.get_optimal_parameters()
+        self._range_analysis()
 
-    def get_optimal_parameters(self):
+    def _range_analysis(self):
         """
         Find the optimal set of hyperparameters by doing range analysis.
 
@@ -143,15 +176,15 @@ class HyperOptOAT(HyperOpt):
             return np.where(self.__OA[:, idx] == val)[0]
 
         R = [
-            [self.trial_losses[indices(idx, l)].sum() for l in range(levels)]
-            for (idx, levels) in enumerate(self.factor_levels)
+            [self._trial_losses[indices(idx, l)].sum() for l in range(levels)]
+            for (idx, levels) in enumerate(self._factor_levels)
         ]
 
         A = [[i / len(j) for i in j] for j in R]
 
         # Taking loss as objective to minimise
-        self.optimal_params = np.array([i.index(min(i)) for i in A])
-        self.importance = np.argsort([max(i) - min(i) for i in A])
+        self._optimal_params = np.array([i.index(min(i)) for i in A])
+        self._importance = np.argsort([max(i) - min(i) for i in A])
 
     def show_order_of_importance(self):
         """Print the order of importance of the hyperparameters."""
@@ -159,7 +192,7 @@ class HyperOptOAT(HyperOpt):
         printout(
             *[
                 self.params.hyperparameters.hlist[idx].name
-                for idx in self.importance
+                for idx in self._importance
             ],
             sep=" < ",
             min_verbosity=0
@@ -172,23 +205,23 @@ class HyperOptOAT(HyperOpt):
         The parameters will be written to the parameter object with which the
         hyperparameter optimizer was created.
         """
-        self.objective.parse_trial_oat(self.optimal_params)
+        self._objective.parse_trial_oat(self._optimal_params)
 
-    def get_orthogonal_array(self):
+    def _get_orthogonal_array(self):
         """
         Generate the best OA used for optimal hyperparameter sampling.
 
         This is function is taken from the example notebook of OApackage.
         """
         self.__check_factor_levels()
-        print("Sorted factor levels:", self.sorted_num_choices)
-        self.n_factors = len(self.params.hyperparameters.hlist)
+        print("Sorted factor levels:", self._sorted_num_choices)
+        self._n_factors = len(self.params.hyperparameters.hlist)
 
-        self.factor_levels = [
+        self._factor_levels = [
             par.num_choices for par in self.params.hyperparameters.hlist
         ]
 
-        self.strength = 2
+        self._strength = 2
         arraylist = None
 
         # This is a little bit hacky.
@@ -200,11 +233,14 @@ class HyperOptOAT(HyperOpt):
         # holds. x is unknown, but we can be confident that it should be
         # small. So simply trying 3 time should be fine for now.
         for i in range(1, 4):
-            self.N_runs = self.number_of_runs() * i
-            print("Trying run size:", self.N_runs)
+            self._N_runs = self._number_of_runs() * i
+            print("Trying run size:", self._N_runs)
             print("Generating Suitable Orthogonal Array.")
             arrayclass = oa.arraydata_t(
-                self.factor_levels, self.N_runs, self.strength, self.n_factors
+                self._factor_levels,
+                self._N_runs,
+                self._strength,
+                self._n_factors,
             )
             arraylist = [arrayclass.create_root()]
 
@@ -212,7 +248,7 @@ class HyperOptOAT(HyperOpt):
             options = oa.OAextend()
             options.setAlgorithmAuto(arrayclass)
 
-            for _ in range(self.strength + 1, self.n_factors + 1):
+            for _ in range(self._strength + 1, self._n_factors + 1):
                 arraylist_extensions = oa.extend_arraylist(
                     arraylist, arrayclass, options
                 )
@@ -231,7 +267,7 @@ class HyperOptOAT(HyperOpt):
         else:
             return np.unique(np.array(arraylist[0]), axis=0)
 
-    def number_of_runs(self):
+    def _number_of_runs(self):
         """
         Calculate the minimum number of runs required for an Orthogonal array.
 
@@ -241,29 +277,20 @@ class HyperOptOAT(HyperOpt):
         """
         runs = [
             np.prod(tt)
-            for tt in itertools.combinations(self.factor_levels, self.strength)
+            for tt in itertools.combinations(
+                self._factor_levels, self._strength
+            )
         ]
 
         N = np.lcm.reduce(runs)
         return int(N)
 
-    def get_best_trial_results(self):
-        """Get the best trial out of the list, including the value."""
-        if self.params.hyperparameters.direction == "minimize":
-            return [np.argmin(self.trial_losses), np.min(self.trial_losses)]
-        elif self.params.hyperparameters.direction == "maximize":
-            return [np.argmax(self.trial_losses), np.max(self.trial_losses)]
-        else:
-            raise Exception(
-                "Invalid direction for hyperparameter optimization selected."
-            )
-
     def __check_factor_levels(self):
         """Check that the factors are in a decreasing order."""
-        dx = np.diff(self.sorted_num_choices)
+        dx = np.diff(self._sorted_num_choices)
         if np.all(dx >= 0):
             # Factors in increasing order, we have to reverse the order.
-            self.sorted_num_choices.reverse()
+            self._sorted_num_choices.reverse()
             self.params.hyperparameters.hlist.reverse()
         elif np.all(dx <= 0):
             # Factors are in decreasing order, we don't have to do anything.
@@ -348,31 +375,33 @@ class HyperOptOAT(HyperOpt):
         with open(file_path, "rb") as handle:
             loaded_tracking_data = pickle.load(handle)
             loaded_hyperopt = HyperOptOAT(params, data)
-            loaded_hyperopt.sorted_num_choices = loaded_tracking_data[
+            loaded_hyperopt._sorted_num_choices = loaded_tracking_data[
                 "sorted_num_choices"
             ]
-            loaded_hyperopt.current_trial = loaded_tracking_data[
+            loaded_hyperopt._current_trial = loaded_tracking_data[
                 "current_trial"
             ]
-            loaded_hyperopt.trial_losses = loaded_tracking_data["trial_losses"]
-            loaded_hyperopt.importance = loaded_tracking_data["importance"]
-            loaded_hyperopt.n_factors = loaded_tracking_data["n_factors"]
-            loaded_hyperopt.factor_levels = loaded_tracking_data[
+            loaded_hyperopt._trial_losses = loaded_tracking_data[
+                "trial_losses"
+            ]
+            loaded_hyperopt._importance = loaded_tracking_data["importance"]
+            loaded_hyperopt._n_factors = loaded_tracking_data["n_factors"]
+            loaded_hyperopt._factor_levels = loaded_tracking_data[
                 "factor_levels"
             ]
-            loaded_hyperopt.strength = loaded_tracking_data["strength"]
-            loaded_hyperopt.N_runs = loaded_tracking_data["N_runs"]
+            loaded_hyperopt._strength = loaded_tracking_data["strength"]
+            loaded_hyperopt._N_runs = loaded_tracking_data["N_runs"]
             loaded_hyperopt.__OA = loaded_tracking_data["OA"]
 
         return loaded_hyperopt
 
     def __create_checkpointing(self, trial):
         """Create a checkpoint of optuna study, if necessary."""
-        self.checkpoint_counter += 1
+        self._checkpoint_counter += 1
         need_to_checkpoint = False
 
         if (
-            self.checkpoint_counter
+            self._checkpoint_counter
             >= self.params.hyperparameters.checkpoints_each_trial
             and self.params.hyperparameters.checkpoints_each_trial > 0
         ):
@@ -386,12 +415,12 @@ class HyperOptOAT(HyperOpt):
             )
         if (
             self.params.hyperparameters.checkpoints_each_trial < 0
-            and np.argmin(self.trial_losses) == self.current_trial - 1
+            and np.argmin(self._trial_losses) == self._current_trial - 1
         ):
             need_to_checkpoint = True
             printout(
                 "Best trial is "
-                + str(self.current_trial - 1)
+                + str(self._current_trial - 1)
                 + ", creating a "
                 "checkpoint for it.",
                 min_verbosity=1,
@@ -399,7 +428,7 @@ class HyperOptOAT(HyperOpt):
 
         if need_to_checkpoint is True:
             # We need to create a checkpoint!
-            self.checkpoint_counter = 0
+            self._checkpoint_counter = 0
 
             self._save_params_and_scaler()
 
@@ -411,14 +440,14 @@ class HyperOptOAT(HyperOpt):
                 )
 
                 study = {
-                    "sorted_num_choices": self.sorted_num_choices,
-                    "current_trial": self.current_trial,
-                    "trial_losses": self.trial_losses,
-                    "importance": self.importance,
-                    "n_factors": self.n_factors,
-                    "factor_levels": self.factor_levels,
-                    "strength": self.strength,
-                    "N_runs": self.N_runs,
+                    "sorted_num_choices": self._sorted_num_choices,
+                    "current_trial": self._current_trial,
+                    "trial_losses": self._trial_losses,
+                    "importance": self._importance,
+                    "n_factors": self._n_factors,
+                    "factor_levels": self._factor_levels,
+                    "strength": self._strength,
+                    "N_runs": self._N_runs,
                     "OA": self.__OA,
                 }
                 with open(hyperopt_name, "wb") as handle:

--- a/mala/network/hyper_opt_optuna.py
+++ b/mala/network/hyper_opt_optuna.py
@@ -25,6 +25,18 @@ class HyperOptOptuna(HyperOpt):
 
     use_pkl_checkpoints : bool
         If true, .pkl checkpoints will be created.
+
+    Attributes
+    ----------
+    params : mala.common.parameters.Parameters
+        MALA Parameters object.
+
+    objective : mala.network.objective_base.ObjectiveBase
+        MALA objective to be optimized, i.e., a MALA NN model training.
+
+    study : optuna.study.Study
+        An Optuna study used to collect the results of the hyperparameter
+        optimization.
     """
 
     def __init__(self, params, data, use_pkl_checkpoints=False):
@@ -93,7 +105,7 @@ class HyperOptOptuna(HyperOpt):
                 load_if_exists=True,
                 pruner=pruner,
             )
-        self.checkpoint_counter = 0
+        self._checkpoint_counter = 0
 
     def perform_study(self):
         """
@@ -101,9 +113,14 @@ class HyperOptOptuna(HyperOpt):
 
         This is done by sampling a certain subset of network architectures.
         In this case, optuna is used.
+
+        Returns
+        -------
+        best_trial_loss : float
+            Loss of the best trial.
         """
         # The parameters could have changed.
-        self.objective = ObjectiveBase(self.params, self.data_handler)
+        self.objective = ObjectiveBase(self.params, self._data_handler)
 
         # Fill callback list based on user checkpoint wishes.
         callback_list = [self.__check_stopping]
@@ -130,6 +147,8 @@ class HyperOptOptuna(HyperOpt):
     def get_trials_from_study(self):
         """
         Return the trials from the last study.
+
+        Only returns completed trials.
 
         Returns
         -------
@@ -350,11 +369,11 @@ class HyperOptOptuna(HyperOpt):
 
     def __create_checkpointing(self, study, trial):
         """Create a checkpoint of optuna study, if necessary."""
-        self.checkpoint_counter += 1
+        self._checkpoint_counter += 1
         need_to_checkpoint = False
 
         if (
-            self.checkpoint_counter
+            self._checkpoint_counter
             >= self.params.hyperparameters.checkpoints_each_trial
             and self.params.hyperparameters.checkpoints_each_trial > 0
         ):
@@ -380,7 +399,7 @@ class HyperOptOptuna(HyperOpt):
 
         if need_to_checkpoint is True:
             # We need to create a checkpoint!
-            self.checkpoint_counter = 0
+            self._checkpoint_counter = 0
 
             self._save_params_and_scaler()
 

--- a/mala/network/hyperparameter.py
+++ b/mala/network/hyperparameter.py
@@ -44,10 +44,33 @@ class Hyperparameter(JSONSerializable):
     choices : list
         List of possible choices (for categorical parameter).
 
-    Returns
-    -------
-    hyperparameter : HyperparameterOptuna or HyperparameterOAT or HyperparameterNASWOT or HyperparameterACSD
-        Hyperparameter in desired format.
+    Attributes
+    ----------
+    opttype : string
+        Datatype of the hyperparameter. Follows optunas naming convetions.
+        In principle supported are:
+
+            - float
+            - int
+            - categorical (list)
+
+        Float and int are not available for OA based approaches at the
+        moment.
+
+    name : string
+        Name of the hyperparameter. Please note that these names always
+        have to be distinct; if you e.g. want to investigate multiple
+        layer sizes use e.g. ff_neurons_layer_001, ff_neurons_layer_002,
+        etc. as names.
+
+    low : float or int
+        Lower bound for numerical parameter.
+
+    high : float or int
+        Higher bound for numerical parameter.
+
+    choices : list
+        List of possible choices (for categorical parameter).
     """
 
     def __new__(

--- a/mala/network/objective_base.py
+++ b/mala/network/objective_base.py
@@ -7,6 +7,7 @@ from mala.network.hyperparameter_optuna import HyperparameterOptuna
 from mala.network.hyperparameter_oat import HyperparameterOAT
 from mala.network.network import Network
 from mala.network.trainer import Trainer
+from mala.common.parameters import Parameters
 from mala import printout
 
 
@@ -29,7 +30,7 @@ class ObjectiveBase:
         data_handler : mala.datahandling.data_handler.DataHandler
             datahandler to be used during the hyperparameter optimization.
         """
-        self.params = params
+        self.params: Parameters = params
         self.data_handler = data_handler
 
         # We need to find out if we have to reparametrize the lists with the

--- a/mala/network/objective_naswot.py
+++ b/mala/network/objective_naswot.py
@@ -46,10 +46,10 @@ class ObjectiveNASWOT(ObjectiveBase):
         batch_size=None,
     ):
         super(ObjectiveNASWOT, self).__init__(search_parameters, data_handler)
-        self.trial_type = trial_type
-        self.batch_size = batch_size
-        if self.batch_size is None:
-            self.batch_size = search_parameters.running.mini_batch_size
+        self._trial_type = trial_type
+        self._batch_size = batch_size
+        if self._batch_size is None:
+            self._batch_size = search_parameters.running.mini_batch_size
 
     def __call__(self, trial):
         """
@@ -83,7 +83,7 @@ class ObjectiveNASWOT(ObjectiveBase):
                 self._data_handler.mix_datasets()
             loader = DataLoader(
                 self._data_handler.training_data_sets[0],
-                batch_size=self.batch_size,
+                batch_size=self._batch_size,
                 shuffle=do_shuffle,
             )
             jac = ObjectiveNASWOT.__get_batch_jacobian(net, loader, device)

--- a/mala/network/objective_naswot.py
+++ b/mala/network/objective_naswot.py
@@ -75,14 +75,14 @@ class ObjectiveNASWOT(ObjectiveBase):
             # Load the batchesand get the jacobian.
             do_shuffle = self.params.running.use_shuffling_for_samplers
             if (
-                self.data_handler.parameters.use_lazy_loading
+                self._data_handler.parameters.use_lazy_loading
                 or self.params.use_ddp
             ):
                 do_shuffle = False
             if self.params.running.use_shuffling_for_samplers:
-                self.data_handler.mix_datasets()
+                self._data_handler.mix_datasets()
             loader = DataLoader(
-                self.data_handler.training_data_sets[0],
+                self._data_handler.training_data_sets[0],
                 batch_size=self.batch_size,
                 shuffle=do_shuffle,
             )

--- a/mala/network/predictor.py
+++ b/mala/network/predictor.py
@@ -139,7 +139,7 @@ class Predictor(Runner):
         self.data.target_calculator.read_additional_calculation_data(
             [atoms, self.data.grid_dimension], "atoms+grid"
         )
-        feature_length = self.data.descriptor_calculator.fingerprint_length
+        feature_length = self.data.descriptor_calculator.feature_size
 
         # The actual calculation of the LDOS from the descriptors depends
         # on whether we run in parallel or serial. In the former case,

--- a/mala/network/predictor.py
+++ b/mala/network/predictor.py
@@ -26,6 +26,12 @@ class Predictor(Runner):
     data : mala.datahandling.data_handler.DataHandler
         DataHandler, in this case not directly holding data, but serving
         as an interface to Target and Descriptor objects.
+
+    Attributes
+    ----------
+    target_calculator : mala.targets.target.Target
+        Target calculator used for predictions. Can be used for further
+        processing.
     """
 
     def __init__(self, params, network, data):
@@ -37,8 +43,8 @@ class Predictor(Runner):
             * self.data.grid_dimension[1]
             * self.data.grid_dimension[2]
         )
-        self.test_data_loader = None
-        self.number_of_batches_per_snapshot = 0
+        self._test_data_loader = None
+        self._number_of_batches_per_snapshot = 0
         self.target_calculator = data.target_calculator
 
     def predict_from_qeout(self, path_to_file, gather_ldos=False):
@@ -228,11 +234,11 @@ class Predictor(Runner):
                 )
                 self.parameters.mini_batch_size = optimal_batch_size
 
-            self.number_of_batches_per_snapshot = int(
+            self._number_of_batches_per_snapshot = int(
                 local_data_size / self.parameters.mini_batch_size
             )
 
-            for i in range(0, self.number_of_batches_per_snapshot):
+            for i in range(0, self._number_of_batches_per_snapshot):
                 sl = slice(
                     i * self.parameters.mini_batch_size,
                     (i + 1) * self.parameters.mini_batch_size,

--- a/mala/network/runner.py
+++ b/mala/network/runner.py
@@ -40,6 +40,20 @@ class Runner:
 
     data : mala.datahandling.data_handler.DataHandler
         DataHandler holding the data for the run.
+
+    Attributes
+    ----------
+    parameters : mala.common.parametes.ParametersRunning
+        MALA neural network training/inference parameters.
+
+    parameters_full : mala.common.parametes.Parameters
+        Full MALA Parameters object.
+
+    network : mala.network.network.Network
+        Network which is being run.
+
+    data : mala.datahandling.data_handler.DataHandler
+        DataHandler holding the data for the run.
     """
 
     def __init__(self, params, network, data, runner_dict=None):

--- a/mala/network/runner.py
+++ b/mala/network/runner.py
@@ -46,7 +46,7 @@ class Runner:
         self.parameters_full: Parameters = params
         self.parameters: ParametersRunning = params.running
         self.network = network
-        self.data = data
+        self.data: DataHandler = data
         self.__prepare_to_run()
 
     def _calculate_errors(

--- a/mala/network/tester.py
+++ b/mala/network/tester.py
@@ -45,6 +45,32 @@ class Tester(Runner):
         Can be "list" or "mae". If "list", then a list of results across all
         snapshots is returned. If "mae", then the MAE across all snapshots
         will be calculated and returned.
+
+    Attributes
+    ----------
+    target_calculator : mala.targets.target.Target
+        Target calculator used for predictions. Can be used for further
+        processing.
+
+    observables_to_test : list
+        List of observables to test. Supported are:
+
+            - "ldos": Calculate the MSE loss of the LDOS.
+            - "band_energy": Band energy error
+            - "band_energy_full": Band energy absolute values (only works with
+              list, as both actual and predicted are returned)
+            - "total_energy": Total energy error
+            - "total_energy_full": Total energy absolute values (only works
+              with list, as both actual and predicted are returned)
+            - "number_of_electrons": Number of electrons (Fermi energy is not
+              determined dynamically for this quantity.
+            - "density": MAPE of the density prediction
+            - "dos": MAPE of the DOS prediction
+
+    output_format : string
+        Can be "list" or "mae". If "list", then a list of results across all
+        snapshots is returned. If "mae", then the MAE across all snapshots
+        will be calculated and returned.
     """
 
     def __init__(
@@ -57,8 +83,8 @@ class Tester(Runner):
     ):
         # copy the parameters into the class.
         super(Tester, self).__init__(params, network, data)
-        self.test_data_loader = None
-        self.number_of_batches_per_snapshot = 0
+        self._test_data_loader = None
+        self._number_of_batches_per_snapshot = 0
         self.observables_to_test = observables_to_test
         self.output_format = output_format
         if self.output_format != "list" and self.output_format != "mae":
@@ -205,7 +231,7 @@ class Tester(Runner):
             offset_snapshots + snapshot_number,
             data_set,
             data_type,
-            self.number_of_batches_per_snapshot,
+            self._number_of_batches_per_snapshot,
             self.parameters.mini_batch_size,
         )
 
@@ -235,6 +261,6 @@ class Tester(Runner):
                 min_verbosity=0,
             )
             self.parameters.mini_batch_size = optimal_batch_size
-        self.number_of_batches_per_snapshot = int(
+        self._number_of_batches_per_snapshot = int(
             grid_size / self.parameters.mini_batch_size
         )

--- a/mala/network/trainer.py
+++ b/mala/network/trainer.py
@@ -43,7 +43,6 @@ class Trainer(Runner):
 
     Attributes
     ----------
-
     final_validation_loss : float
         Validation loss after training
 

--- a/mala/targets/atomic_force.py
+++ b/mala/targets/atomic_force.py
@@ -3,6 +3,7 @@
 from ase.units import Rydberg, Bohr
 
 from .target import Target
+from mala.common.parallelizer import parallel_warn
 
 
 class AtomicForce(Target):
@@ -24,6 +25,10 @@ class AtomicForce(Target):
             Parameters used to create this TargetBase object.
 
         """
+        parallel_warn(
+            "The AtomicForce class is currently be developed and"
+            " not feature-complete."
+        )
         super(AtomicForce, self).__init__(params)
 
     def get_feature_size(self):

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -29,12 +29,23 @@ from mala.descriptors.atomic_density import AtomicDensity
 
 
 class Density(Target):
-    """Postprocessing / parsing functions for the electronic density.
+    """
+    Postprocessing / parsing functions for the electronic density.
 
     Parameters
     ----------
     params : mala.common.parameters.Parameters
         Parameters used to create this Target object.
+
+    Attributes
+    ----------
+    density : numpy.ndarray
+        Electronic charge density as a volumetric array. May be 4D or 2D
+        depending on workflow.
+
+    te_mutex : bool
+        Total energy module mutual exclusion token used to make sure there
+        the total energy module is not initialized twice.
     """
 
     ##############################
@@ -278,6 +289,12 @@ class Density(Target):
 
         This is the generic interface for cached target quantities.
         It should work for all implemented targets.
+
+        Returns
+        -------
+        density : numpy.ndarray
+            Electronic charge density as a volumetric array. May be 4D or 2D
+            depending on workflow.
         """
         return self.density
 
@@ -407,7 +424,8 @@ class Density(Target):
             Units the density is saved in. Usually none.
         """
         printout("Reading density from .cube file ", path, min_verbosity=0)
-        # automatically convert units if they are None since cube files take atomic units
+        # automatically convert units if they are None since cube files take
+        # atomic units
         if units is None:
             units = "1/Bohr^3"
         if units != "1/Bohr^3":

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -600,7 +600,7 @@ class Density(Target):
 
         voxel : ase.cell.Cell
             Voxel to be used for grid intergation. Needs to reflect the
-            symmetry of the simulation cell. In Bohr.
+            symmetry of the simulation cell.
 
         integration_method : str
             Integration method used to integrate density on the grid.

--- a/mala/targets/density.py
+++ b/mala/targets/density.py
@@ -36,22 +36,15 @@ class Density(Target):
     ----------
     params : mala.common.parameters.Parameters
         Parameters used to create this Target object.
-
-    Attributes
-    ----------
-    density : numpy.ndarray
-        Electronic charge density as a volumetric array. May be 4D or 2D
-        depending on workflow.
-
-    te_mutex : bool
-        Total energy module mutual exclusion token used to make sure there
-        the total energy module is not initialized twice.
     """
 
     ##############################
     # Class attributes
     ##############################
-
+    """
+    Total energy module mutual exclusion token used to make sure there
+    the total energy module is not initialized twice.
+    """
     te_mutex = False
 
     ##############################

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -28,11 +28,6 @@ class DOS(Target):
     ----------
     params : mala.common.parameters.Parameters
         Parameters used to create this TargetBase object.
-
-    Attributes
-    ----------
-    density_of_states : numpy.ndarray
-        Electronic density of states.
     """
 
     ##############################

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -28,6 +28,11 @@ class DOS(Target):
     ----------
     params : mala.common.parameters.Parameters
         Parameters used to create this TargetBase object.
+
+    Attributes
+    ----------
+    density_of_states : numpy.ndarray
+        Electronic density of states.
     """
 
     ##############################
@@ -248,6 +253,12 @@ class DOS(Target):
 
         This is the generic interface for cached target quantities.
         It should work for all implemented targets.
+
+        Returns
+        -------
+        density_of_states : numpy.ndarray
+            Electronic density of states.
+
         """
         return self.density_of_states
 

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -34,6 +34,13 @@ class LDOS(Target):
     ----------
     params : mala.common.parameters.Parameters
         Parameters used to create this LDOS object.
+
+    Attributes
+    ----------
+
+    local_density_of_states : numpy.ndarray
+        Electronic local density of states as a volumetric array.
+        May be 4D- or 2D depending on workflow.
     """
 
     ##############################
@@ -239,6 +246,11 @@ class LDOS(Target):
 
         This is the generic interface for cached target quantities.
         It should work for all implemented targets.
+
+        Returns
+        local_density_of_states : numpy.ndarray
+            Electronic local density of states as a volumetric array.
+            May be 4D- or 2D depending on workflow.
         """
         return self.local_density_of_states
 
@@ -597,8 +609,6 @@ class LDOS(Target):
 
         If neither LDOS nor DOS+Density data is provided, the cached LDOS will
         be attempted to be used for the calculation.
-
-
 
         Parameters
         ----------

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -34,13 +34,6 @@ class LDOS(Target):
     ----------
     params : mala.common.parameters.Parameters
         Parameters used to create this LDOS object.
-
-    Attributes
-    ----------
-
-    local_density_of_states : numpy.ndarray
-        Electronic local density of states as a volumetric array.
-        May be 4D- or 2D depending on workflow.
     """
 
     ##############################
@@ -248,6 +241,7 @@ class LDOS(Target):
         It should work for all implemented targets.
 
         Returns
+        -------
         local_density_of_states : numpy.ndarray
             Electronic local density of states as a volumetric array.
             May be 4D- or 2D depending on workflow.

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -34,11 +34,66 @@ class Target(PhysicalData):
     (i.e. the quantity the NN will learn to predict) from a specified file
     format and performs postprocessing calculations on the quantity.
 
+    Target parsers often read DFT reference information.
+
     Parameters
     ----------
     params : mala.common.parameters.Parameters or
     mala.common.parameters.ParametersTargets
         Parameters used to create this Target object.
+
+    Attributes
+    ----------
+    atomic_forces_dft : numpy.ndarray
+        Atomic forces as per DFT reference file.
+
+    atoms : ase.Atoms
+        ASE atoms object used for calculations.
+
+    band_energy_dft_calculation
+        Band energy as per DFT reference file.
+
+    electrons_per_atom : int
+        Electrons per atom, usually determined by DFT reference file.
+
+    entropy_contribution_dft_calculation : float
+        Electronic entropy contribution as per DFT reference file.
+
+    fermi_energy_dft : float
+        Fermi energy as per DFT reference file.
+
+    kpoints : list
+        k-grid used for MALA calculations. Managed internally.
+
+    local_grid : list
+        Size of local grid (in MPI mode).
+
+    number_of_electrons_exact
+        Exact number of electrons, usually given via DFT reference file.
+
+    number_of_electrons_from_eigenvals : float
+        Number of electrons as calculated from DFT reference eigenvalues.
+
+    parameters : mala.common.parameters.ParametersTarget
+        MALA target calculation parameters.
+
+    qe_input_data : dict
+        Quantum ESPRESSO data dictionary, read from DFT reference file and
+        used for the total energy module.
+
+    qe_pseudopotentials : list
+        List of Quantum ESPRESSO pseudopotentials, read from DFT reference file
+         and used for the total energy module.
+
+    save_target_data : bool
+        Control whether target data will be saved. Can be important for I/O
+        applications. Managed internally, default is True.
+
+    temperature
+    total_energy_contributions_dft_calculation
+    total_energy_dft_calculation
+    voxel
+    y_planes
     """
 
     ##############################
@@ -1608,7 +1663,7 @@ class Target(PhysicalData):
             "electrons_per_atom",
             default_value=self.electrons_per_atom,
         )
-        self.number_of_electrons_from_eigenval = (
+        self.number_of_electrons_from_eigenvals = (
             self._get_attribute_if_attribute_exists(
                 iteration,
                 "number_of_electrons_from_eigenvals",

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -89,11 +89,30 @@ class Target(PhysicalData):
         Control whether target data will be saved. Can be important for I/O
         applications. Managed internally, default is True.
 
-    temperature
-    total_energy_contributions_dft_calculation
-    total_energy_dft_calculation
-    voxel
-    y_planes
+    temperature : float
+        Temperature used for all computations. By default read from DFT
+        reference file, but can freely be changed from the outside.
+
+    total_energy_contributions_dft_calculation : dict
+        Dictionary holding contributions to total free energy not given
+        as individual properties, as read from the DFT reference file.
+        Contains:
+
+            - "one_electron_contribution", :math:`n\,V_\mathrm{xc}` plus band
+              energy
+            - "hartree_contribution", :math:`E_\mathrm{H}`
+            - "xc_contribution", :math:`E_\mathrm{xc}`
+            - "ewald_contribution", :math:`E_\mathrm{Ewald}`
+
+    total_energy_dft_calculation : float
+        Total free energy as read from DFT reference file.
+    voxel : ase.cell.Cell
+        Voxel to be used for grid intergation. Reflects the
+        symmetry of the simulation cell. Calculated from DFT reference data.
+
+    y_planes : int
+        Number of y_planes used for Quantum ESPRESSO parallelization. Handled
+        internally.
     """
 
     ##############################
@@ -153,7 +172,6 @@ class Target(PhysicalData):
         Get the necessary arguments to call __new__.
 
         Used for pickling.
-
 
         Returns
         -------
@@ -847,7 +865,14 @@ class Target(PhysicalData):
         raise Exception("No method implement to calculate an energy grid.")
 
     def get_real_space_grid(self):
-        """Get the real space grid."""
+        """
+        Get the real space grid.
+
+        Returns
+        -------
+        grid3D : numpy.ndarray
+            Numpy array holding the entire grid.
+        """
         grid3D = np.zeros(
             (
                 self.grid_dimensions[0],
@@ -1429,8 +1454,7 @@ class Target(PhysicalData):
             None.
 
         mpi_rank : int
-            Rank within MPI
-
+            Rank within MPI.
         """
         # Specify grid dimensions, if any are given.
         if (

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -27,7 +27,7 @@ from mala.descriptors.atomic_density import AtomicDensity
 
 
 class Target(PhysicalData):
-    """
+    r"""
     Base class for all target quantity parser.
 
     Target parsers read the target quantity
@@ -76,10 +76,6 @@ class Target(PhysicalData):
 
     parameters : mala.common.parameters.ParametersTarget
         MALA target calculation parameters.
-
-    qe_input_data : dict
-        Quantum ESPRESSO data dictionary, read from DFT reference file and
-        used for the total energy module.
 
     qe_pseudopotentials : list
         List of Quantum ESPRESSO pseudopotentials, read from DFT reference file

--- a/test/all_lazy_loading_test.py
+++ b/test/all_lazy_loading_test.py
@@ -110,34 +110,34 @@ class TestLazyLoading:
                     # I presume to be due to numerical constraints. To make a
                     # meaningful comparison it is wise to scale the value here.
                     this_result.append(
-                        data_handler.input_data_scaler._total_mean
+                        data_handler.input_data_scaler.total_mean
                         / data_handler.nr_training_data
                     )
                     this_result.append(
-                        data_handler.input_data_scaler._total_std
+                        data_handler.input_data_scaler.total_std
                         / data_handler.nr_training_data
                     )
                     this_result.append(
-                        data_handler.output_data_scaler._total_mean
+                        data_handler.output_data_scaler.total_mean
                         / data_handler.nr_training_data
                     )
                     this_result.append(
-                        data_handler.output_data_scaler._total_std
+                        data_handler.output_data_scaler.total_std
                         / data_handler.nr_training_data
                     )
                 elif scalingtype == "normal":
                     torch.manual_seed(2002)
                     this_result.append(
-                        data_handler.input_data_scaler._total_max
+                        data_handler.input_data_scaler.total_max
                     )
                     this_result.append(
-                        data_handler.input_data_scaler._total_min
+                        data_handler.input_data_scaler.total_min
                     )
                     this_result.append(
-                        data_handler.output_data_scaler._total_max
+                        data_handler.output_data_scaler.total_max
                     )
                     this_result.append(
-                        data_handler.output_data_scaler._total_min
+                        data_handler.output_data_scaler.total_min
                     )
                     dataset_tester.append(
                         (data_handler.training_data_sets[0][3998])[0].sum()
@@ -165,41 +165,41 @@ class TestLazyLoading:
                     # I presume to be due to numerical constraints. To make a
                     # meaningful comparison it is wise to scale the value here.
                     this_result.append(
-                        torch.mean(data_handler.input_data_scaler._means)
+                        torch.mean(data_handler.input_data_scaler.means)
                         / data_handler.parameters.snapshot_directories_list[
                             0
                         ].grid_size
                     )
                     this_result.append(
-                        torch.mean(data_handler.input_data_scaler._stds)
+                        torch.mean(data_handler.input_data_scaler.stds)
                         / data_handler.parameters.snapshot_directories_list[
                             0
                         ].grid_size
                     )
                     this_result.append(
-                        torch.mean(data_handler.output_data_scaler._means)
+                        torch.mean(data_handler.output_data_scaler.means)
                         / data_handler.parameters.snapshot_directories_list[
                             0
                         ].grid_size
                     )
                     this_result.append(
-                        torch.mean(data_handler.output_data_scaler._stds)
+                        torch.mean(data_handler.output_data_scaler.stds)
                         / data_handler.parameters.snapshot_directories_list[
                             0
                         ].grid_size
                     )
                 elif scalingtype == "feature-wise-normal":
                     this_result.append(
-                        torch.mean(data_handler.input_data_scaler._maxs)
+                        torch.mean(data_handler.input_data_scaler.maxs)
                     )
                     this_result.append(
-                        torch.mean(data_handler.input_data_scaler._mins)
+                        torch.mean(data_handler.input_data_scaler.mins)
                     )
                     this_result.append(
-                        torch.mean(data_handler.output_data_scaler._maxs)
+                        torch.mean(data_handler.output_data_scaler.maxs)
                     )
                     this_result.append(
-                        torch.mean(data_handler.output_data_scaler._mins)
+                        torch.mean(data_handler.output_data_scaler.mins)
                     )
 
                 comparison.append(this_result)

--- a/test/all_lazy_loading_test.py
+++ b/test/all_lazy_loading_test.py
@@ -110,34 +110,34 @@ class TestLazyLoading:
                     # I presume to be due to numerical constraints. To make a
                     # meaningful comparison it is wise to scale the value here.
                     this_result.append(
-                        data_handler.input_data_scaler.total_mean
+                        data_handler.input_data_scaler._total_mean
                         / data_handler.nr_training_data
                     )
                     this_result.append(
-                        data_handler.input_data_scaler.total_std
+                        data_handler.input_data_scaler._total_std
                         / data_handler.nr_training_data
                     )
                     this_result.append(
-                        data_handler.output_data_scaler.total_mean
+                        data_handler.output_data_scaler._total_mean
                         / data_handler.nr_training_data
                     )
                     this_result.append(
-                        data_handler.output_data_scaler.total_std
+                        data_handler.output_data_scaler._total_std
                         / data_handler.nr_training_data
                     )
                 elif scalingtype == "normal":
                     torch.manual_seed(2002)
                     this_result.append(
-                        data_handler.input_data_scaler.total_max
+                        data_handler.input_data_scaler._total_max
                     )
                     this_result.append(
-                        data_handler.input_data_scaler.total_min
+                        data_handler.input_data_scaler._total_min
                     )
                     this_result.append(
-                        data_handler.output_data_scaler.total_max
+                        data_handler.output_data_scaler._total_max
                     )
                     this_result.append(
-                        data_handler.output_data_scaler.total_min
+                        data_handler.output_data_scaler._total_min
                     )
                     dataset_tester.append(
                         (data_handler.training_data_sets[0][3998])[0].sum()
@@ -165,41 +165,41 @@ class TestLazyLoading:
                     # I presume to be due to numerical constraints. To make a
                     # meaningful comparison it is wise to scale the value here.
                     this_result.append(
-                        torch.mean(data_handler.input_data_scaler.means)
+                        torch.mean(data_handler.input_data_scaler._means)
                         / data_handler.parameters.snapshot_directories_list[
                             0
                         ].grid_size
                     )
                     this_result.append(
-                        torch.mean(data_handler.input_data_scaler.stds)
+                        torch.mean(data_handler.input_data_scaler._stds)
                         / data_handler.parameters.snapshot_directories_list[
                             0
                         ].grid_size
                     )
                     this_result.append(
-                        torch.mean(data_handler.output_data_scaler.means)
+                        torch.mean(data_handler.output_data_scaler._means)
                         / data_handler.parameters.snapshot_directories_list[
                             0
                         ].grid_size
                     )
                     this_result.append(
-                        torch.mean(data_handler.output_data_scaler.stds)
+                        torch.mean(data_handler.output_data_scaler._stds)
                         / data_handler.parameters.snapshot_directories_list[
                             0
                         ].grid_size
                     )
                 elif scalingtype == "feature-wise-normal":
                     this_result.append(
-                        torch.mean(data_handler.input_data_scaler.maxs)
+                        torch.mean(data_handler.input_data_scaler._maxs)
                     )
                     this_result.append(
-                        torch.mean(data_handler.input_data_scaler.mins)
+                        torch.mean(data_handler.input_data_scaler._mins)
                     )
                     this_result.append(
-                        torch.mean(data_handler.output_data_scaler.maxs)
+                        torch.mean(data_handler.output_data_scaler._maxs)
                     )
                     this_result.append(
-                        torch.mean(data_handler.output_data_scaler.mins)
+                        torch.mean(data_handler.output_data_scaler._mins)
                     )
 
                 comparison.append(this_result)

--- a/test/checkpoint_training_test.py
+++ b/test/checkpoint_training_test.py
@@ -45,7 +45,7 @@ class TestTrainingCheckpoint:
             learning_rate=0.1,
         )
         trainer.train_network()
-        original_learning_rate = trainer.optimizer.param_groups[0]["lr"]
+        original_learning_rate = trainer._optimizer.param_groups[0]["lr"]
 
         # Now do the same, but cut at epoch 22 and see if it recovers the
         # correct result.
@@ -58,7 +58,7 @@ class TestTrainingCheckpoint:
         trainer.train_network()
         trainer = self.__resume_checkpoint(test_checkpoint_name, 40)
         trainer.train_network()
-        new_learning_rate = trainer.optimizer.param_groups[0]["lr"]
+        new_learning_rate = trainer._optimizer.param_groups[0]["lr"]
         assert np.isclose(
             original_learning_rate, new_learning_rate, atol=accuracy
         )

--- a/test/checkpoint_training_test.py
+++ b/test/checkpoint_training_test.py
@@ -73,7 +73,7 @@ class TestTrainingCheckpoint:
             learning_rate=0.1,
         )
         trainer.train_network()
-        original_nr_epochs = trainer.last_epoch
+        original_nr_epochs = trainer._last_epoch
 
         # Now do the same, but cut at epoch 22 and see if it recovers the
         # correct result.
@@ -86,7 +86,7 @@ class TestTrainingCheckpoint:
         trainer.train_network()
         trainer = self.__resume_checkpoint(test_checkpoint_name, 40)
         trainer.train_network()
-        last_nr_epochs = trainer.last_epoch
+        last_nr_epochs = trainer._last_epoch
 
         # integer comparison!
         assert original_nr_epochs == last_nr_epochs

--- a/test/complete_interfaces_test.py
+++ b/test/complete_interfaces_test.py
@@ -251,7 +251,7 @@ class TestInterfaces:
             reference_data=os.path.join(data_path, "Be_snapshot1.out"),
         )
         total_energy_dft_calculation = (
-            calculator.data_handler.target_calculator.total_energy_dft_calculation
+            calculator._data_handler.target_calculator.total_energy_dft_calculation
         )
         calculator.calculate(atoms, properties=["energy"])
         assert np.isclose(

--- a/test/complete_interfaces_test.py
+++ b/test/complete_interfaces_test.py
@@ -117,7 +117,7 @@ class TestInterfaces:
             descriptor_save_path="./",
             target_save_path="./",
             additional_info_save_path="./",
-            naming_scheme="converted_from_numpy_*.bp5",
+            naming_scheme="converted_from_numpy_*.h5",
             descriptor_calculation_kwargs={"working_directory": "./"},
         )
 
@@ -128,11 +128,13 @@ class TestInterfaces:
         for snapshot in range(2):
             data_converter.add_snapshot(
                 descriptor_input_type="openpmd",
-                descriptor_input_path="converted_from_numpy_{}.in.bp5".format(
+                descriptor_input_path="converted_from_numpy_{}.in.h5".format(
                     snapshot
                 ),
                 target_input_type="openpmd",
-                target_input_path="converted_from_numpy_{}.out.bp5".format(snapshot),
+                target_input_path="converted_from_numpy_{}.out.h5".format(
+                    snapshot
+                ),
                 additional_info_input_type=None,
                 additional_info_input_path=None,
                 target_units=None,
@@ -151,8 +153,10 @@ class TestInterfaces:
                 original = os.path.join(
                     data_path, "Be_snapshot{}.{}.npy".format(snapshot, i_o)
                 )
-                roundtrip = "verify_against_original_numpy_data_{}.{}.npy".format(
-                    snapshot, i_o
+                roundtrip = (
+                    "verify_against_original_numpy_data_{}.{}.npy".format(
+                        snapshot, i_o
+                    )
                 )
                 import numpy as np
 

--- a/test/hyperopt_test.py
+++ b/test/hyperopt_test.py
@@ -294,7 +294,7 @@ class TestHyperparameterOptimization:
         for idx, trial in enumerate(correct_trial_list):
             assert np.isclose(
                 trial,
-                test_hp_optimizer.trial_losses[idx],
+                test_hp_optimizer._trial_losses[idx],
                 rtol=naswot_accuracy,
             )
 

--- a/test/inference_test.py
+++ b/test/inference_test.py
@@ -33,7 +33,7 @@ class TestInference:
 
         # Confirm that unit conversion does not introduce any errors.
 
-        from_file_1 = data_handler.target_calculator.convert_units(
+        from_file_1 = data_handler._target_calculator.convert_units(
             np.load(
                 os.path.join(data_path, "Be_snapshot" + str(0) + ".out.npy")
             ),
@@ -41,7 +41,7 @@ class TestInference:
         )
         from_file_2 = np.load(
             os.path.join(data_path, "Be_snapshot" + str(0) + ".out.npy")
-        ) * data_handler.target_calculator.convert_units(
+        ) * data_handler._target_calculator.convert_units(
             1, in_units="1/(eV*Bohr^3)"
         )
 

--- a/test/inference_test.py
+++ b/test/inference_test.py
@@ -33,7 +33,7 @@ class TestInference:
 
         # Confirm that unit conversion does not introduce any errors.
 
-        from_file_1 = data_handler._target_calculator.convert_units(
+        from_file_1 = data_handler.target_calculator.convert_units(
             np.load(
                 os.path.join(data_path, "Be_snapshot" + str(0) + ".out.npy")
             ),
@@ -41,7 +41,7 @@ class TestInference:
         )
         from_file_2 = np.load(
             os.path.join(data_path, "Be_snapshot" + str(0) + ".out.npy")
-        ) * data_handler._target_calculator.convert_units(
+        ) * data_handler.target_calculator.convert_units(
             1, in_units="1/(eV*Bohr^3)"
         )
 


### PR DESCRIPTION
This PR aims to close #587. Some have already been taken care of in #609, but generally there are quite some functions missing docstrings. Especially I initially forgot to add "Attributes" docstrings to many classes. In looking through this I realized how many classes have "public" (I know, I know, python's concept of privacy are a bit dubious) members for things only used internally, which I think can be avoided. This PR also addresses this; the idea is that every variable publicly available is documented, and everything else is private (either the "polite" private with a single underscore or the actually enforces private with two underscores which does not get inherited). I will not alter the doc strings already touched by #609.  