### PR TITLE
Recovering DDP scalability

### DIFF
--- a/mala/network/trainer.py
+++ b/mala/network/trainer.py
@@ -678,196 +678,17 @@ class Trainer(Runner):
                 # If only the LDOS is in the validation metrics (as is the
                 # case for, e.g., distributed network trainings), we can
                 # use a faster (or at least better parallelizing) code
+
                 if (
                     len(self.parameters.validation_metrics) == 1
                     and self.parameters.validation_metrics[0] == "ldos"
                 ):
-                    validation_loss_sum = torch.zeros(
-                        1, device=self.parameters._configuration["device"]
+
+                    errors[data_set_type]["ldos"] = (
+                        self.__calculate_validation_error_ldos_only(
+                            data_loaders
+                        )
                     )
-                    with torch.no_grad():
-                        if self.parameters._configuration["gpu"]:
-                            report_freq = self.parameters.training_log_interval
-                            torch.cuda.synchronize(
-                                self.parameters._configuration["device"]
-                            )
-                            tsample = time.time()
-                            batchid = 0
-                            for loader in data_loaders:
-                                for x, y in loader:
-                                    x = x.to(
-                                        self.parameters._configuration[
-                                            "device"
-                                        ],
-                                        non_blocking=True,
-                                    )
-                                    y = y.to(
-                                        self.parameters._configuration[
-                                            "device"
-                                        ],
-                                        non_blocking=True,
-                                    )
-
-                                    if (
-                                        self.parameters.use_graphs
-                                        and self._validation_graph is None
-                                    ):
-                                        printout(
-                                            "Capturing CUDA graph for validation.",
-                                            min_verbosity=2,
-                                        )
-                                        s = torch.cuda.Stream(
-                                            self.parameters._configuration[
-                                                "device"
-                                            ]
-                                        )
-                                        s.wait_stream(
-                                            torch.cuda.current_stream(
-                                                self.parameters._configuration[
-                                                    "device"
-                                                ]
-                                            )
-                                        )
-                                        # Warmup for graphs
-                                        with torch.cuda.stream(s):
-                                            for _ in range(20):
-                                                with torch.cuda.amp.autocast(
-                                                    enabled=self.parameters.use_mixed_precision
-                                                ):
-                                                    prediction = self.network(
-                                                        x
-                                                    )
-                                                    if (
-                                                        self.parameters_full.use_ddp
-                                                    ):
-                                                        loss = self.network.module.calculate_loss(
-                                                            prediction, y
-                                                        )
-                                                    else:
-                                                        loss = self.network.calculate_loss(
-                                                            prediction, y
-                                                        )
-                                        torch.cuda.current_stream(
-                                            self.parameters._configuration[
-                                                "device"
-                                            ]
-                                        ).wait_stream(s)
-
-                                        # Create static entry point tensors to graph
-                                        self.static_input_validation = (
-                                            torch.empty_like(x)
-                                        )
-                                        self.static_target_validation = (
-                                            torch.empty_like(y)
-                                        )
-
-                                        # Capture graph
-                                        self._validation_graph = (
-                                            torch.cuda.CUDAGraph()
-                                        )
-                                        with torch.cuda.graph(
-                                            self._validation_graph
-                                        ):
-                                            with torch.cuda.amp.autocast(
-                                                enabled=self.parameters.use_mixed_precision
-                                            ):
-                                                self.static_prediction_validation = self.network(
-                                                    self.static_input_validation
-                                                )
-                                                if (
-                                                    self.parameters_full.use_ddp
-                                                ):
-                                                    self.static_loss_validation = self.network.module.calculate_loss(
-                                                        self.static_prediction_validation,
-                                                        self.static_target_validation,
-                                                    )
-                                                else:
-                                                    self.static_loss_validation = self.network.calculate_loss(
-                                                        self.static_prediction_validation,
-                                                        self.static_target_validation,
-                                                    )
-
-                                    if self._validation_graph:
-                                        self.static_input_validation.copy_(x)
-                                        self.static_target_validation.copy_(y)
-                                        self._validation_graph.replay()
-                                        validation_loss_sum += (
-                                            self.static_loss_validation
-                                        )
-                                    else:
-                                        with torch.cuda.amp.autocast(
-                                            enabled=self.parameters.use_mixed_precision
-                                        ):
-                                            prediction = self.network(x)
-                                            if self.parameters_full.use_ddp:
-                                                loss = self.network.module.calculate_loss(
-                                                    prediction, y
-                                                )
-                                            else:
-                                                loss = self.network.calculate_loss(
-                                                    prediction, y
-                                                )
-                                            validation_loss_sum += loss
-                                    if (
-                                        batchid != 0
-                                        and (batchid + 1) % report_freq == 0
-                                    ):
-                                        torch.cuda.synchronize(
-                                            self.parameters._configuration[
-                                                "device"
-                                            ]
-                                        )
-                                        sample_time = time.time() - tsample
-                                        avg_sample_time = (
-                                            sample_time / report_freq
-                                        )
-                                        avg_sample_tput = (
-                                            report_freq
-                                            * x.shape[0]
-                                            / sample_time
-                                        )
-                                        printout(
-                                            f"batch {batchid + 1}, "  # /{total_samples}, "
-                                            f"validation avg time: {avg_sample_time} "
-                                            f"validation avg throughput: {avg_sample_tput}",
-                                            min_verbosity=2,
-                                        )
-                                        tsample = time.time()
-                                    batchid += 1
-                            torch.cuda.synchronize(
-                                self.parameters._configuration["device"]
-                            )
-                        else:
-                            batchid = 0
-                            for loader in data_loaders:
-                                for x, y in loader:
-                                    x = x.to(
-                                        self.parameters._configuration[
-                                            "device"
-                                        ]
-                                    )
-                                    y = y.to(
-                                        self.parameters._configuration[
-                                            "device"
-                                        ]
-                                    )
-                                    prediction = self.network(x)
-                                    if self.parameters_full.use_ddp:
-                                        validation_loss_sum += (
-                                            self.network.module.calculate_loss(
-                                                prediction, y
-                                            ).item()
-                                        )
-                                    else:
-                                        validation_loss_sum += (
-                                            self.network.calculate_loss(
-                                                prediction, y
-                                            ).item()
-                                        )
-                                    batchid += 1
-
-                    validation_loss = validation_loss_sum.item() / batchid
-                    errors[data_set_type]["ldos"] = validation_loss
 
                 else:
                     with torch.no_grad():
@@ -911,6 +732,150 @@ class Trainer(Runner):
                                     calculated_errors[metric]
                                 )
         return errors
+
+    def __calculate_validation_error_ldos_only(self, data_loaders):
+        validation_loss_sum = torch.zeros(
+            1, device=self.parameters._configuration["device"]
+        )
+        with torch.no_grad():
+            if self.parameters._configuration["gpu"]:
+                report_freq = self.parameters.training_log_interval
+                torch.cuda.synchronize(
+                    self.parameters._configuration["device"]
+                )
+                tsample = time.time()
+                batchid = 0
+                for loader in data_loaders:
+                    for x, y in loader:
+                        x = x.to(
+                            self.parameters._configuration["device"],
+                            non_blocking=True,
+                        )
+                        y = y.to(
+                            self.parameters._configuration["device"],
+                            non_blocking=True,
+                        )
+
+                        if (
+                            self.parameters.use_graphs
+                            and self._validation_graph is None
+                        ):
+                            printout(
+                                "Capturing CUDA graph for validation.",
+                                min_verbosity=2,
+                            )
+                            s = torch.cuda.Stream(
+                                self.parameters._configuration["device"]
+                            )
+                            s.wait_stream(
+                                torch.cuda.current_stream(
+                                    self.parameters._configuration["device"]
+                                )
+                            )
+                            # Warmup for graphs
+                            with torch.cuda.stream(s):
+                                for _ in range(20):
+                                    with torch.cuda.amp.autocast(
+                                        enabled=self.parameters.use_mixed_precision
+                                    ):
+                                        prediction = self.network(x)
+                                        if self.parameters_full.use_ddp:
+                                            loss = self.network.module.calculate_loss(
+                                                prediction, y
+                                            )
+                                        else:
+                                            loss = self.network.calculate_loss(
+                                                prediction, y
+                                            )
+                            torch.cuda.current_stream(
+                                self.parameters._configuration["device"]
+                            ).wait_stream(s)
+
+                            # Create static entry point tensors to graph
+                            self.static_input_validation = torch.empty_like(x)
+                            self.static_target_validation = torch.empty_like(y)
+
+                            # Capture graph
+                            self._validation_graph = torch.cuda.CUDAGraph()
+                            with torch.cuda.graph(self._validation_graph):
+                                with torch.cuda.amp.autocast(
+                                    enabled=self.parameters.use_mixed_precision
+                                ):
+                                    self.static_prediction_validation = (
+                                        self.network(
+                                            self.static_input_validation
+                                        )
+                                    )
+                                    if self.parameters_full.use_ddp:
+                                        self.static_loss_validation = self.network.module.calculate_loss(
+                                            self.static_prediction_validation,
+                                            self.static_target_validation,
+                                        )
+                                    else:
+                                        self.static_loss_validation = self.network.calculate_loss(
+                                            self.static_prediction_validation,
+                                            self.static_target_validation,
+                                        )
+
+                        if self._validation_graph:
+                            self.static_input_validation.copy_(x)
+                            self.static_target_validation.copy_(y)
+                            self._validation_graph.replay()
+                            validation_loss_sum += self.static_loss_validation
+                        else:
+                            with torch.cuda.amp.autocast(
+                                enabled=self.parameters.use_mixed_precision
+                            ):
+                                prediction = self.network(x)
+                                if self.parameters_full.use_ddp:
+                                    loss = self.network.module.calculate_loss(
+                                        prediction, y
+                                    )
+                                else:
+                                    loss = self.network.calculate_loss(
+                                        prediction, y
+                                    )
+                                validation_loss_sum += loss
+                        if batchid != 0 and (batchid + 1) % report_freq == 0:
+                            torch.cuda.synchronize(
+                                self.parameters._configuration["device"]
+                            )
+                            sample_time = time.time() - tsample
+                            avg_sample_time = sample_time / report_freq
+                            avg_sample_tput = (
+                                report_freq * x.shape[0] / sample_time
+                            )
+                            printout(
+                                f"batch {batchid + 1}, "  # /{total_samples}, "
+                                f"validation avg time: {avg_sample_time} "
+                                f"validation avg throughput: {avg_sample_tput}",
+                                min_verbosity=2,
+                            )
+                            tsample = time.time()
+                        batchid += 1
+                torch.cuda.synchronize(
+                    self.parameters._configuration["device"]
+                )
+            else:
+                batchid = 0
+                for loader in data_loaders:
+                    for x, y in loader:
+                        x = x.to(self.parameters._configuration["device"])
+                        y = y.to(self.parameters._configuration["device"])
+                        prediction = self.network(x)
+                        if self.parameters_full.use_ddp:
+                            validation_loss_sum += (
+                                self.network.module.calculate_loss(
+                                    prediction, y
+                                ).item()
+                            )
+                        else:
+                            validation_loss_sum += self.network.calculate_loss(
+                                prediction, y
+                            ).item()
+                        batchid += 1
+
+        return validation_loss_sum.item() / batchid
 
     def __prepare_to_train(self, optimizer_dict):
         """Prepare everything for training."""

--- a/mala/network/trainer.py
+++ b/mala/network/trainer.py
@@ -675,46 +675,241 @@ class Trainer(Runner):
                         )
                     loader_id += 1
             else:
-                with torch.no_grad():
-                    for snapshot_number in trange(
-                        offset_snapshots,
-                        number_of_snapshots + offset_snapshots,
-                        desc="Validation",
-                        disable=self.parameters_full.verbosity < 2,
-                    ):
-                        # Get optimal batch size and number of batches per snapshotss
-                        grid_size = (
-                            self.data.parameters.snapshot_directories_list[
-                                snapshot_number
-                            ].grid_size
-                        )
+                # If only the LDOS is in the validation metrics (as is the
+                # case for, e.g., distributed network trainings), we can
+                # use a faster (or at least better parallelizing) code
+                if (
+                    len(self.parameters.validation_metrics) == 1
+                    and self.parameters.validation_metrics[0] == "ldos"
+                ):
+                    validation_loss_sum = torch.zeros(
+                        1, device=self.parameters._configuration["device"]
+                    )
+                    with torch.no_grad():
+                        if self.parameters._configuration["gpu"]:
+                            report_freq = self.parameters.training_log_interval
+                            torch.cuda.synchronize(
+                                self.parameters._configuration["device"]
+                            )
+                            tsample = time.time()
+                            batchid = 0
+                            for loader in data_loaders:
+                                for x, y in loader:
+                                    x = x.to(
+                                        self.parameters._configuration[
+                                            "device"
+                                        ],
+                                        non_blocking=True,
+                                    )
+                                    y = y.to(
+                                        self.parameters._configuration[
+                                            "device"
+                                        ],
+                                        non_blocking=True,
+                                    )
 
-                        optimal_batch_size = self._correct_batch_size(
-                            grid_size, self.parameters.mini_batch_size
-                        )
-                        number_of_batches_per_snapshot = int(
-                            grid_size / optimal_batch_size
-                        )
+                                    if (
+                                        self.parameters.use_graphs
+                                        and self.validation_graph is None
+                                    ):
+                                        printout(
+                                            "Capturing CUDA graph for validation.",
+                                            min_verbosity=2,
+                                        )
+                                        s = torch.cuda.Stream(
+                                            self.parameters._configuration[
+                                                "device"
+                                            ]
+                                        )
+                                        s.wait_stream(
+                                            torch.cuda.current_stream(
+                                                self.parameters._configuration[
+                                                    "device"
+                                                ]
+                                            )
+                                        )
+                                        # Warmup for graphs
+                                        with torch.cuda.stream(s):
+                                            for _ in range(20):
+                                                with torch.cuda.amp.autocast(
+                                                    enabled=self.parameters.use_mixed_precision
+                                                ):
+                                                    prediction = self.network(
+                                                        x
+                                                    )
+                                                    if (
+                                                        self.parameters_full.use_ddp
+                                                    ):
+                                                        loss = self.network.module.calculate_loss(
+                                                            prediction, y
+                                                        )
+                                                    else:
+                                                        loss = self.network.calculate_loss(
+                                                            prediction, y
+                                                        )
+                                        torch.cuda.current_stream(
+                                            self.parameters._configuration[
+                                                "device"
+                                            ]
+                                        ).wait_stream(s)
 
-                        actual_outputs, predicted_outputs = (
-                            self._forward_entire_snapshot(
+                                        # Create static entry point tensors to graph
+                                        self.static_input_validation = (
+                                            torch.empty_like(x)
+                                        )
+                                        self.static_target_validation = (
+                                            torch.empty_like(y)
+                                        )
+
+                                        # Capture graph
+                                        self.validation_graph = (
+                                            torch.cuda.CUDAGraph()
+                                        )
+                                        with torch.cuda.graph(
+                                            self.validation_graph
+                                        ):
+                                            with torch.cuda.amp.autocast(
+                                                enabled=self.parameters.use_mixed_precision
+                                            ):
+                                                self.static_prediction_validation = self.network(
+                                                    self.static_input_validation
+                                                )
+                                                if (
+                                                    self.parameters_full.use_ddp
+                                                ):
+                                                    self.static_loss_validation = self.network.module.calculate_loss(
+                                                        self.static_prediction_validation,
+                                                        self.static_target_validation,
+                                                    )
+                                                else:
+                                                    self.static_loss_validation = self.network.calculate_loss(
+                                                        self.static_prediction_validation,
+                                                        self.static_target_validation,
+                                                    )
+
+                                    if self.validation_graph:
+                                        self.static_input_validation.copy_(x)
+                                        self.static_target_validation.copy_(y)
+                                        self.validation_graph.replay()
+                                        validation_loss_sum += (
+                                            self.static_loss_validation
+                                        )
+                                    else:
+                                        with torch.cuda.amp.autocast(
+                                            enabled=self.parameters.use_mixed_precision
+                                        ):
+                                            prediction = self.network(x)
+                                            if self.parameters_full.use_ddp:
+                                                loss = self.network.module.calculate_loss(
+                                                    prediction, y
+                                                )
+                                            else:
+                                                loss = self.network.calculate_loss(
+                                                    prediction, y
+                                                )
+                                            validation_loss_sum += loss
+                                    if (
+                                        batchid != 0
+                                        and (batchid + 1) % report_freq == 0
+                                    ):
+                                        torch.cuda.synchronize(
+                                            self.parameters._configuration[
+                                                "device"
+                                            ]
+                                        )
+                                        sample_time = time.time() - tsample
+                                        avg_sample_time = (
+                                            sample_time / report_freq
+                                        )
+                                        avg_sample_tput = (
+                                            report_freq
+                                            * x.shape[0]
+                                            / sample_time
+                                        )
+                                        printout(
+                                            f"batch {batchid + 1}, "  # /{total_samples}, "
+                                            f"validation avg time: {avg_sample_time} "
+                                            f"validation avg throughput: {avg_sample_tput}",
+                                            min_verbosity=2,
+                                        )
+                                        tsample = time.time()
+                                    batchid += 1
+                            torch.cuda.synchronize(
+                                self.parameters._configuration["device"]
+                            )
+                        else:
+                            batchid = 0
+                            for loader in data_loaders:
+                                for x, y in loader:
+                                    x = x.to(
+                                        self.parameters._configuration[
+                                            "device"
+                                        ]
+                                    )
+                                    y = y.to(
+                                        self.parameters._configuration[
+                                            "device"
+                                        ]
+                                    )
+                                    prediction = self.network(x)
+                                    if self.parameters_full.use_ddp:
+                                        validation_loss_sum += (
+                                            self.network.module.calculate_loss(
+                                                prediction, y
+                                            ).item()
+                                        )
+                                    else:
+                                        validation_loss_sum += (
+                                            self.network.calculate_loss(
+                                                prediction, y
+                                            ).item()
+                                        )
+                                    batchid += 1
+
+                    validation_loss = validation_loss_sum.item() / batchid
+                    errors[data_set_type]["ldos"] = validation_loss
+
+                else:
+                    with torch.no_grad():
+                        for snapshot_number in trange(
+                            offset_snapshots,
+                            number_of_snapshots + offset_snapshots,
+                            desc="Validation",
+                            disable=self.parameters_full.verbosity < 2,
+                        ):
+                            # Get optimal batch size and number of batches per snapshotss
+                            grid_size = (
+                                self.data.parameters.snapshot_directories_list[
+                                    snapshot_number
+                                ].grid_size
+                            )
+
+                            optimal_batch_size = self._correct_batch_size(
+                                grid_size, self.parameters.mini_batch_size
+                            )
+                            number_of_batches_per_snapshot = int(
+                                grid_size / optimal_batch_size
+                            )
+
+                            actual_outputs, predicted_outputs = (
+                                self._forward_entire_snapshot(
+                                    snapshot_number,
+                                    data_sets[0],
+                                    data_set_type[0:2],
+                                    number_of_batches_per_snapshot,
+                                    optimal_batch_size,
+                                )
+                            )
+                            calculated_errors = self._calculate_errors(
+                                actual_outputs,
+                                predicted_outputs,
+                                metrics,
                                 snapshot_number,
-                                data_sets[0],
-                                data_set_type[0:2],
-                                number_of_batches_per_snapshot,
-                                optimal_batch_size,
                             )
-                        )
-                        calculated_errors = self._calculate_errors(
-                            actual_outputs,
-                            predicted_outputs,
-                            metrics,
-                            snapshot_number,
-                        )
-                        for metric in metrics:
-                            errors[data_set_type][metric].append(
-                                calculated_errors[metric]
-                            )
+                            for metric in metrics:
+                                errors[data_set_type][metric].append(
+                                    calculated_errors[metric]
+                                )
         return errors
 
     def __prepare_to_train(self, optimizer_dict):

--- a/mala/network/trainer.py
+++ b/mala/network/trainer.py
@@ -710,7 +710,7 @@ class Trainer(Runner):
 
                                     if (
                                         self.parameters.use_graphs
-                                        and self.validation_graph is None
+                                        and self._validation_graph is None
                                     ):
                                         printout(
                                             "Capturing CUDA graph for validation.",
@@ -762,11 +762,11 @@ class Trainer(Runner):
                                         )
 
                                         # Capture graph
-                                        self.validation_graph = (
+                                        self._validation_graph = (
                                             torch.cuda.CUDAGraph()
                                         )
                                         with torch.cuda.graph(
-                                            self.validation_graph
+                                            self._validation_graph
                                         ):
                                             with torch.cuda.amp.autocast(
                                                 enabled=self.parameters.use_mixed_precision
@@ -787,10 +787,10 @@ class Trainer(Runner):
                                                         self.static_target_validation,
                                                     )
 
-                                    if self.validation_graph:
+                                    if self._validation_graph:
                                         self.static_input_validation.copy_(x)
                                         self.static_target_validation.copy_(y)
-                                        self.validation_graph.replay()
+                                        self._validation_graph.replay()
                                         validation_loss_sum += (
                                             self.static_loss_validation
                                         )


### PR DESCRIPTION
I recently realized that using the current `develop` branch of MALA does not reproduce the DDP scaling results achieved upon implementation (#466). Looking into the code, the issue is with the change in how the validation loss is calculated, which occured in #560. #560 unifies the error calculation throughout MALA, which is in general very helpful, but there is one small caveat that I didn't realize at that time: it uses `_forward_entire_snapshot` to compute predictions on the validation snapshots. That function is (apparently) not as parallelizable through DDP as the direct LDOS validation loss calculation implemented previously. Of course it has the advantage that it gives predictions *per snapshot* and one therefore can access band energy, total energy, etc. as metrics during training. 

These should not be used (at least for now) during DDP training anyway though. So this PR recovers the original DDP scaling behavior by defaulting back to the old validation loss routine if only the LDOS is tracked and using the new scheme everywhere else. I will further open an issue to eventually look into `_forward_entire_snapshot` to figure out *why* it does not work as well in DDP. 

I will attach scaling results to confirm this is working now. As a side note, for a single GPU, the new route actually seems to be faster.

![problem01](https://github.com/user-attachments/assets/ce058522-9b43-4291-a71f-40695d4efd91)
![problem02](https://github.com/user-attachments/assets/43b536f1-0d2b-458b-ad30-c0bbcacab199)