### PR TITLE
Make caching the descriptor calculation input files optional

### DIFF
--- a/mala/common/parameters.py
+++ b/mala/common/parameters.py
@@ -447,9 +447,10 @@ class ParametersDescriptors(ParametersBase):
         used for model training itself, this parameter needs to be set.
 
     custom_lammps_compute_file : str
-        Path to a LAMMPS compute file for the bispectrum descriptor
-        calculation. MALA has its own collection of compute files which are
-        used by default. Setting this parameter is thus not necessarys for
+        Path to a LAMMPS compute file for the descriptor calculation.
+        MALA has its own collection of compute files which are
+        used by default, i.e., when this string is empty.
+        Setting this parameter is thus not necessarys for
         model training and inference, and it exists mainly for debugging
         purposes.
 

--- a/mala/common/parameters.py
+++ b/mala/common/parameters.py
@@ -446,7 +446,7 @@ class ParametersDescriptors(ParametersBase):
         mainly exists for debugging purposes. If the atomic density is instead
         used for model training itself, this parameter needs to be set.
 
-    lammps_compute_file : str
+    custom_lammps_compute_file : str
         Path to a LAMMPS compute file for the bispectrum descriptor
         calculation. MALA has its own collection of compute files which are
         used by default. Setting this parameter is thus not necessarys for
@@ -476,7 +476,7 @@ class ParametersDescriptors(ParametersBase):
 
         # These affect all descriptors, at least as long all descriptors
         # use LAMMPS (which they currently do).
-        self.lammps_compute_file = ""
+        self.custom_lammps_compute_file = ""
         self.descriptors_contain_xyz = True
 
         # TODO: I would rather handle the parallelization info automatically
@@ -590,7 +590,7 @@ class ParametersDescriptors(ParametersBase):
 
         # There may have been a serial or parallel run before that is now
         # no longer valid.
-        self.lammps_compute_file = ""
+        self.custom_lammps_compute_file = ""
 
 
 class ParametersTargets(ParametersBase):

--- a/mala/descriptors/atomic_density.py
+++ b/mala/descriptors/atomic_density.py
@@ -211,23 +211,26 @@ class AtomicDensity(Descriptor):
 
         # For now the file is chosen automatically, because this is used
         # mostly under the hood anyway.
-        filepath = __file__.split("atomic_density")[0]
-        if self.parameters._configuration["mpi"]:
-            if self.parameters.use_z_splitting:
-                self.parameters.lammps_compute_file = os.path.join(
-                    filepath, "in.ggrid.python"
-                )
+        if self.parameters.custom_lammps_compute_file != "":
+            lammps_compute_file = self.parameters.custom_lammps_compute_file
+        else:
+            filepath = __file__.split("atomic_density")[0]
+            if self.parameters._configuration["mpi"]:
+                if self.parameters.use_z_splitting:
+                    lammps_compute_file = os.path.join(
+                        filepath, "in.ggrid.python"
+                    )
+                else:
+                    lammps_compute_file = os.path.join(
+                        filepath, "in.ggrid_defaultproc.python"
+                    )
             else:
-                self.parameters.lammps_compute_file = os.path.join(
+                lammps_compute_file = os.path.join(
                     filepath, "in.ggrid_defaultproc.python"
                 )
-        else:
-            self.parameters.lammps_compute_file = os.path.join(
-                filepath, "in.ggrid_defaultproc.python"
-            )
 
         # Do the LAMMPS calculation and clean up.
-        lmp.file(self.parameters.lammps_compute_file)
+        lmp.file(lammps_compute_file)
 
         # Extract the data.
         nrows_ggrid = extract_compute_np(

--- a/mala/descriptors/atomic_density.py
+++ b/mala/descriptors/atomic_density.py
@@ -214,7 +214,7 @@ class AtomicDensity(Descriptor):
         if self.parameters.custom_lammps_compute_file != "":
             lammps_compute_file = self.parameters.custom_lammps_compute_file
         else:
-            filepath = __file__.split("atomic_density")[0]
+            filepath = os.path.dirname(__file__)
             if self.parameters._configuration["mpi"]:
                 if self.parameters.use_z_splitting:
                     lammps_compute_file = os.path.join(

--- a/mala/descriptors/bispectrum.py
+++ b/mala/descriptors/bispectrum.py
@@ -229,24 +229,26 @@ class Bispectrum(Descriptor):
 
         # An empty string means that the user wants to use the standard input.
         # What that is differs depending on serial/parallel execution.
-        if self.parameters.lammps_compute_file == "":
+        # We also have to ensure that no input files from a different
+        # descriptor calculator gets used.
+        if self.parameters.custom_lammps_compute_file != "":
+            lammps_compute_file = self.parameters.custom_lammps_compute_file
+        else:
             filepath = __file__.split("bispectrum")[0]
             if self.parameters._configuration["mpi"]:
                 if self.parameters.use_z_splitting:
-                    self.parameters.lammps_compute_file = os.path.join(
+                    lammps_compute_file = os.path.join(
                         filepath, "in.bgridlocal.python"
                     )
                 else:
-                    self.parameters.lammps_compute_file = os.path.join(
+                    lammps_compute_file = os.path.join(
                         filepath, "in.bgridlocal_defaultproc.python"
                     )
             else:
-                self.parameters.lammps_compute_file = os.path.join(
-                    filepath, "in.bgrid.python"
-                )
+                lammps_compute_file = os.path.join(filepath, "in.bgrid.python")
 
         # Do the LAMMPS calculation and clean up.
-        lmp.file(self.parameters.lammps_compute_file)
+        lmp.file(lammps_compute_file)
         self.feature_size = self.__get_feature_size()
 
         # Extract data from LAMMPS calculation.

--- a/mala/descriptors/bispectrum.py
+++ b/mala/descriptors/bispectrum.py
@@ -234,7 +234,7 @@ class Bispectrum(Descriptor):
         if self.parameters.custom_lammps_compute_file != "":
             lammps_compute_file = self.parameters.custom_lammps_compute_file
         else:
-            filepath = __file__.split("bispectrum")[0]
+            filepath = os.path.dirname(__file__)
             if self.parameters._configuration["mpi"]:
                 if self.parameters.use_z_splitting:
                     lammps_compute_file = os.path.join(

--- a/mala/descriptors/minterpy_descriptors.py
+++ b/mala/descriptors/minterpy_descriptors.py
@@ -186,23 +186,28 @@ class MinterpyDescriptors(Descriptor):
 
             # For now the file is chosen automatically, because this is used
             # mostly under the hood anyway.
-            filepath = __file__.split("minterpy")[0]
-            if self.parameters._configuration["mpi"]:
-                raise Exception(
-                    "Minterpy descriptors cannot be calculated "
-                    "in parallel yet."
+            if self.parameters.custom_lammps_compute_file != "":
+                lammps_compute_file = (
+                    self.parameters.custom_lammps_compute_file
                 )
-                # if self.parameters.use_z_splitting:
-                #     runfile = os.path.join(filepath, "in.ggrid.python")
-                # else:
-                #     runfile = os.path.join(filepath, "in.ggrid_defaultproc.python")
             else:
-                self.parameters.lammps_compute_file = os.path.join(
-                    filepath, "in.ggrid_defaultproc.python"
-                )
+                filepath = __file__.split("minterpy")[0]
+                if self.parameters._configuration["mpi"]:
+                    raise Exception(
+                        "Minterpy descriptors cannot be calculated "
+                        "in parallel yet."
+                    )
+                    # if self.parameters.use_z_splitting:
+                    #     runfile = os.path.join(filepath, "in.ggrid.python")
+                    # else:
+                    #     runfile = os.path.join(filepath, "in.ggrid_defaultproc.python")
+                else:
+                    lammps_compute_file = os.path.join(
+                        filepath, "in.ggrid_defaultproc.python"
+                    )
 
             # Do the LAMMPS calculation and clean up.
-            lmp.file(self.parameters.lammps_compute_file)
+            lmp.file(lammps_compute_file)
 
             # Extract the data.
             nrows_ggrid = extract_compute_np(

--- a/mala/descriptors/minterpy_descriptors.py
+++ b/mala/descriptors/minterpy_descriptors.py
@@ -191,7 +191,7 @@ class MinterpyDescriptors(Descriptor):
                     self.parameters.custom_lammps_compute_file
                 )
             else:
-                filepath = __file__.split("minterpy")[0]
+                filepath = os.path.dirname(__file__)
                 if self.parameters._configuration["mpi"]:
                     raise Exception(
                         "Minterpy descriptors cannot be calculated "


### PR DESCRIPTION
This PR changes the behavior of `parameters.descriptors.lammps_compute_file` (and renames it to `custom_lammps_compute_file`). Originally, the idea of this parameter was to allow users to supply custom LAMMPS compute files while also saving the compute files used during inference. This PR keeps the former usage, which may be useful for debugging, but removes this "caching" feature, because it leads to problems when multiple types of descriptors are computed during the same inference (e.g., when Bispectrum and AtomicDensity descriptors are needed to calculate the total energy). 