### PR TITLE
Splitting the (L)DOS along the energy axis

### DIFF
--- a/mala/common/parameters.py
+++ b/mala/common/parameters.py
@@ -604,14 +604,31 @@ class ParametersTargets(ParametersBase):
         Number of points in the energy grid that is used to calculate the
         (L)DOS.
 
-    ldos_gridsize : int
-        Gridsize of the LDOS.
+    ldos_gridsize : int or list
+        Gridsize of the LDOS. Can either be an int or a list of ints,
+        in which case splitting of the (L)DOS along the energy axis is assumed.
+        Note that this splitting feature is currently experimental and the
+        interface may change in the future. Further, if this type of splitting
+        is used, please make sure that ldos_gridsize, ldos_gridspacing_ev
+        and ldos_gridoffset_ev are lists of the same length.
 
-    ldos_gridspacing_ev: float
+    ldos_gridspacing_ev: float or list
         Gridspacing of the energy grid the (L)DOS is evaluated on [eV].
+        Can either be a float or a list of floats, in which case splitting of
+        the (L)DOS along the energy axis is assumed.
+        Note that this splitting feature is currently experimental and the
+        interface may change in the future. Further, if this type of splitting
+        is used, please make sure that ldos_gridsize, ldos_gridspacing_ev
+        and ldos_gridoffset_ev are lists of the same length.
 
-    ldos_gridoffset_ev: float
+    ldos_gridoffset_ev: float or list
         Lowest energy value on the (L)DOS energy grid [eV].
+        Can either be a float or a list of floats, in which case splitting of
+        the (L)DOS along the energy axis is assumed.
+        Note that this splitting feature is currently experimental and the
+        interface may change in the future. Further, if this type of splitting
+        is used, please make sure that ldos_gridsize, ldos_gridspacing_ev
+        and ldos_gridoffset_ev are lists of the same length.
 
     pseudopotential_path : string
         Path at which pseudopotentials are located (for TEM).

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -445,6 +445,14 @@ class DOS(Target):
             # Open the file, then iterate through its contents.
             with open(readpath, "r") as infile:
                 lines = infile.readlines()
+
+                # Directly at the split we discard the last energy value
+                # of the left side of the split. This requires that both
+                # DOS have been sampled to/from the EXACT same value.
+                # Currently, this responsibility lies with the user, and I
+                # am not sure if we can consistently check for this, even
+                # if we wanted to. In the DOS case, the energies get reported,
+                # but that is NOT the case in the LDOS case.
                 end = (
                     self.parameters.ldos_gridsize[path_index] - 1
                     if path_index != len(readpaths) - 1

--- a/mala/targets/dos.py
+++ b/mala/targets/dos.py
@@ -36,35 +36,6 @@ class DOS(Target):
 
     def __init__(self, params):
         super(DOS, self).__init__(params)
-
-        split = (
-            isinstance(self.parameters.ldos_gridsize, list)
-            and isinstance(self.parameters.ldos_gridoffset_ev, list)
-            and isinstance(self.parameters.ldos_gridspacing_ev, list)
-        )
-        no_split = (
-            isinstance(self.parameters.ldos_gridsize, int)
-            and isinstance(self.parameters.ldos_gridoffset_ev, int)
-            and isinstance(self.parameters.ldos_gridspacing_ev, int)
-        )
-        if not (split or no_split):
-            raise Exception(
-                "All DOS related parameters (grid size, offset and "
-                "spacing) must be either a single value or "
-                "a list."
-            )
-        if split:
-            if not (
-                len(self.parameters.ldos_gridsize)
-                == len(self.parameters.ldos_gridoffset_ev)
-                and len(self.parameters.ldos_gridsize)
-                == len(self.parameters.ldos_gridspacing_ev)
-            ):
-                raise Exception(
-                    "All DOS related parameters (grid size, offset and "
-                    "spacing) must be of same length if splitting along"
-                    "the energy axis is performed."
-                )
         self.density_of_states = None
 
     @classmethod
@@ -301,7 +272,7 @@ class DOS(Target):
     @cached_property
     def energy_grid(self):
         """Energy grid on which the DOS is expressed."""
-        return self.get_energy_grid()
+        return self._get_energy_grid()
 
     @cached_property
     def band_energy(self):
@@ -597,40 +568,6 @@ class DOS(Target):
 
     # Calculations
     ##############
-
-    def get_energy_grid(self):
-        """
-        Get energy grid.
-
-        Returns
-        -------
-        e_grid : numpy.ndarray
-            Energy grid on which the DOS is defined.
-        """
-        if isinstance(self.parameters.ldos_gridsize, int):
-            gridsizes = [self.parameters.ldos_gridsize]
-            offsets = [self.parameters.ldos_gridoffset_ev]
-            spacings = [self.parameters.ldos_gridspacing_ev]
-        else:
-            gridsizes = self.parameters.ldos_gridsize
-            offsets = self.parameters.ldos_gridoffset_ev
-            spacings = self.parameters.ldos_gridspacing_ev
-
-        for i in range(len(gridsizes)):
-            emin = offsets[i]
-            emax = offsets[i] + gridsizes[i] * spacings[i]
-            linspace_array = np.linspace(
-                emin, emax, gridsizes[i], endpoint=False
-            )
-            if i != len(gridsizes) - 1:
-                linspace_array = linspace_array[:-1]
-
-            if i == 0:
-                e_grid = linspace_array
-            else:
-                e_grid = np.concatenate((e_grid, linspace_array))
-
-        return e_grid
 
     def get_band_energy(
         self,

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -198,7 +198,15 @@ class LDOS(Target):
         if isinstance(self.parameters.ldos_gridsize, int):
             return self.parameters.ldos_gridsize
         elif isinstance(self.parameters.ldos_gridsize, list):
-            return np.sum(self.parameters.ldos_gridsize)
+            # For splits, we sum up the individual grid sizes, BUT we
+            # have to subtract one for each split, as the last energy
+            # of each section gets discarded. So for three sections,
+            # we have to subtract 2.
+            return (
+                np.sum(self.parameters.ldos_gridsize)
+                - len(self.parameters.ldos_gridsize)
+                + 1
+            )
 
     @property
     def data_name(self):

--- a/mala/targets/ldos.py
+++ b/mala/targets/ldos.py
@@ -482,7 +482,7 @@ class LDOS(Target):
 
         Parameters
         ----------
-        path_scheme : string
+        path_scheme : string or list[string]
             Naming scheme for the LDOS .cube files. Every asterisk will be
             replaced with an appropriate number for the LDOS files. Before
             the file name, please make sure to include the proper file path.
@@ -1626,6 +1626,7 @@ class LDOS(Target):
         digits = [int(math.log10(x)) + 1 for x in ldos_grid_sizes]
 
         file_list = []
+        path_scheme_string = ""
         for path_index, _path_scheme in enumerate(path_scheme_list):
 
             # Directly at the split we discard the last energy value
@@ -1640,6 +1641,11 @@ class LDOS(Target):
                 if path_index != len(path_scheme_list) - 1
                 else ldos_grid_sizes[path_index]
             ) + 1
+
+            # For diagnostic output.
+            path_scheme_string += _path_scheme
+            if path_index != len(path_scheme_list) - 1:
+                path_scheme_string += ", "
 
             # Actually fill the file list.
             for i in range(1, end):
@@ -1656,11 +1662,12 @@ class LDOS(Target):
 
         # Iterate over the amount of specified LDOS input files.
         # QE is a Fortran code, so everything is 1 based.
+
         printout(
             "Reading "
             + str(len(file_list))
             + " LDOS files from"
-            + path_scheme
+            + path_scheme_string
             + ".",
             min_verbosity=0,
         )

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -1933,6 +1933,12 @@ class Target(PhysicalData):
                 "a list."
             )
         if split:
+            parallel_warn(
+                "Splitting along energy axis for LDOS, this "
+                "feature is currently experimental. Correctness "
+                "of results has been verified for most systems, "
+                "but the interface may change in the future."
+            )
             if not (
                 len(self.parameters.ldos_gridsize)
                 == len(self.parameters.ldos_gridoffset_ev)

--- a/mala/targets/target.py
+++ b/mala/targets/target.py
@@ -856,9 +856,42 @@ class Target(PhysicalData):
     # Calculations
     ##############
 
-    def get_energy_grid(self):
-        """Get energy grid."""
-        raise Exception("No method implement to calculate an energy grid.")
+    def _get_energy_grid(self):
+        """
+        Get energy grid.
+
+        Returns
+        -------
+        e_grid : numpy.ndarray
+            Energy grid on which the DOS is defined.
+        """
+        # Check consistency before actually calculating the energy grid.
+        self._check_energy_grid_parameter_consistency()
+
+        if isinstance(self.parameters.ldos_gridsize, int):
+            gridsizes = [self.parameters.ldos_gridsize]
+            offsets = [self.parameters.ldos_gridoffset_ev]
+            spacings = [self.parameters.ldos_gridspacing_ev]
+        else:
+            gridsizes = self.parameters.ldos_gridsize
+            offsets = self.parameters.ldos_gridoffset_ev
+            spacings = self.parameters.ldos_gridspacing_ev
+
+        for i in range(len(gridsizes)):
+            emin = offsets[i]
+            emax = offsets[i] + gridsizes[i] * spacings[i]
+            linspace_array = np.linspace(
+                emin, emax, gridsizes[i], endpoint=False
+            )
+            if i != len(gridsizes) - 1:
+                linspace_array = linspace_array[:-1]
+
+            if i == 0:
+                e_grid = linspace_array
+            else:
+                e_grid = np.concatenate((e_grid, linspace_array))
+
+        return e_grid
 
     def get_real_space_grid(self):
         """
@@ -1872,6 +1905,45 @@ class Target(PhysicalData):
             An ASE atoms object holding the associated atoms of this object.
         """
         return self.atoms
+
+    def _check_energy_grid_parameter_consistency(self):
+        """
+        Check consistency of parameters related to energy grid.
+
+        These can either be singular values or lists, dependent on whether
+        splitting along the energy domain is used.
+        """
+        split = (
+            isinstance(self.parameters.ldos_gridsize, list)
+            and isinstance(self.parameters.ldos_gridoffset_ev, list)
+            and isinstance(self.parameters.ldos_gridspacing_ev, list)
+        )
+        no_split = (
+            isinstance(self.parameters.ldos_gridsize, int)
+            and (
+                isinstance(self.parameters.ldos_gridoffset_ev, int)
+                or isinstance(self.parameters.ldos_gridoffset_ev, float)
+            )
+            and isinstance(self.parameters.ldos_gridspacing_ev, float)
+        )
+        if not (split or no_split):
+            raise Exception(
+                "All DOS related parameters (grid size, offset and "
+                "spacing) must be either a single value or "
+                "a list."
+            )
+        if split:
+            if not (
+                len(self.parameters.ldos_gridsize)
+                == len(self.parameters.ldos_gridoffset_ev)
+                and len(self.parameters.ldos_gridsize)
+                == len(self.parameters.ldos_gridspacing_ev)
+            ):
+                raise Exception(
+                    "All DOS related parameters (grid size, offset and "
+                    "spacing) must be of same length if splitting along"
+                    "the energy axis is performed."
+                )
 
     @staticmethod
     def _get_ideal_rmax_for_rdf(atoms: ase.Atoms, method="mic"):

--- a/test/splitting_test.py
+++ b/test/splitting_test.py
@@ -1,0 +1,84 @@
+import os
+
+import numpy as np
+
+import mala
+from mala.datahandling.data_repo import data_path
+
+
+class TestSplitting:
+    """
+    Class that tests that splitted (L)DOS data can be processed
+
+    Splitted means along the energy domain.
+    """
+
+    def test_ldos_splitting(self):
+        parameters3 = mala.Parameters()
+        parameters3.targets.ldos_gridsize = [
+            3,
+            3,
+            7,
+        ]
+        parameters3.targets.ldos_gridoffset_ev = [-5, 0, 5]
+        parameters3.targets.ldos_gridspacing_ev = [2.5, 2.5, 2.5]
+        cubes_path = os.path.join(data_path, "cubes")
+        ldos_calculator3 = mala.LDOS(parameters3)
+        ldos_calculator3.read_from_cube(
+            [
+                os.path.join(cubes_path, "tmp.pp0*Be_part1_ldos.cube"),
+                os.path.join(cubes_path, "tmp.pp0*Be_part2_ldos.cube"),
+                os.path.join(cubes_path, "tmp.pp0*Be_part3_ldos.cube"),
+            ]
+        )
+
+        parameters = mala.Parameters()
+        parameters.targets.ldos_gridsize = 11
+        parameters.targets.ldos_gridspacing_ev = 2.5
+        parameters.targets.ldos_gridoffset_ev = -5
+        ldos_calculator = mala.LDOS(parameters)
+        ldos_calculator.read_from_cube(
+            os.path.join(cubes_path, "tmp.pp*Be_ldos.cube")
+        )
+
+        print(
+            np.mean(
+                np.abs(
+                    ldos_calculator3.local_density_of_states
+                    - ldos_calculator.local_density_of_states
+                )
+            )
+        )
+
+    def test_dos_splitting(self):
+        parameters3 = mala.Parameters()
+        parameters3.targets.ldos_gridsize = [
+            3,
+            3,
+            7,
+        ]
+        parameters3.targets.ldos_gridoffset_ev = [-5, 0, 5]
+        parameters3.targets.ldos_gridspacing_ev = [2.5, 2.5, 2.5]
+        cubes_path = os.path.join(data_path, "cubes")
+        dos_calculator3 = mala.DOS(parameters3)
+        dos_calculator3.read_from_qe_out(
+            os.path.join(data_path, "Be_snapshot1.out")
+        )
+
+        parameters = mala.Parameters()
+        parameters.targets.ldos_gridsize = 11
+        parameters.targets.ldos_gridspacing_ev = 2.5
+        parameters.targets.ldos_gridoffset_ev = -5
+        dos_calculator = mala.DOS(parameters)
+        dos_calculator.read_from_qe_out(
+            os.path.join(data_path, "Be_snapshot1.out")
+        )
+
+        print(
+            np.mean(
+                np.abs(
+                    dos_calculator3.density_of_states
+                    - dos_calculator.density_of_states
+                )
+            )
+        )


### PR DESCRIPTION
Current projects surrounding 2D materials and multi-component systems necessitate that MALA can process data which has been split along the energy axis; i.e., an LDOS that was sampled multiple times for different energy windows. This could happen if, e.g., part of the (L)DOS needs to be sampled on a finer energy grid (graphene project) or we are dealing with core electrons (larger atoms, multi-component systems). This PR establishes principal functionality of this splitting, adds a test and a bit of documentation. Further documentation on the process is necessary once the feature has been amply tested. Also, currently not tested are scenarios where parts of the DOS are _not sampled at all_, i.e., core electron and valence electron settings, where part of the DOS is just not computed, because it is zero. I think this should work with this implementation already, but I have not tested it, because it will be investigated as part of #606 .