### PR TITLE
Update runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -118,7 +118,7 @@ jobs:
 
   cpu-tests:
     needs: build-docker-image-cpu
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       IMAGE_REPO: ${{ needs.build-docker-image-cpu.outputs.image-repo }}
       DOCKER_TAG: ${{ needs.build-docker-image-cpu.outputs.docker-tag }}


### PR DESCRIPTION
As per https://github.com/actions/runner-images/issues/11101.

If I understand correctly, we are already using the 22.04 in two places, and the 20.04 in a different one. I am not sure of the top of my head what the reason for this was, so for now I updated and we'll see what needs fixing. 